### PR TITLE
feat(domain): Enhance GlobalSettingsService event broadcasting and pe…

### DIFF
--- a/novade-domain/src/global_settings_management/persistence.rs
+++ b/novade-domain/src/global_settings_management/persistence.rs
@@ -92,7 +92,7 @@ impl SettingsPersistenceProvider for FilesystemSettingsProvider {
             // We might need a new variant in GlobalSettingsError or use a placeholder.
             // Using a descriptive string for now.
             GlobalSettingsError::SerializationError{
-                path: crate::global_settings_management::paths::SettingPath::Appearance(crate::global_settings_management::paths::AppearanceSettingPath::ActiveThemeName), // Placeholder path for now
+                path_description: None, // Error is for the entire settings object
                 source_message: e.to_string()
             }
             // A more general variant might be:

--- a/novade-domain/src/global_settings_management/types.rs
+++ b/novade-domain/src/global_settings_management/types.rs
@@ -217,6 +217,23 @@ pub struct SettingsLoadedEvent {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)] // Added Default
 pub struct SettingsSavedEvent; // Empty struct, just a notification
 
+// --- Global Event Enum ---
+
+/// Represents any event that can occur within the global settings management system.
+///
+/// This enum aggregates specific event types, allowing subscribers to listen for a broader
+/// category of setting-related changes or a specific one.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum GlobalSettingsEvent {
+    /// Indicates that a specific setting value has changed.
+    SettingChanged(SettingChangedEvent),
+    /// Indicates that a complete set of settings has been loaded.
+    /// This is often dispatched on application startup or when settings are reset.
+    SettingsLoaded(SettingsLoadedEvent),
+    /// Confirms that the current settings state has been successfully persisted.
+    SettingsSaved(SettingsSavedEvent),
+}
+
 impl AppearanceSettings {
     pub fn validate(&self) -> Result<(), String> {
         if self.active_theme_name.is_empty() {


### PR DESCRIPTION
…rsistence

This change introduces a new `GlobalSettingsEvent` enum to broadcast a wider range of settings-related events: `SettingChanged`, `SettingsLoaded`, and `SettingsSaved`.

Key changes:
- Modified `DefaultGlobalSettingsService` to use `GlobalSettingsEvent` for its broadcast channel.
- `SettingsLoaded` events are now dispatched after settings are loaded from persistence or reset to defaults.
- `SettingsSaved` events are now dispatched after settings are successfully saved to persistence.
- The event subscription method in `GlobalSettingsService` trait and `DefaultGlobalSettingsService` has been renamed to `subscribe_to_events` and now returns a receiver for `GlobalSettingsEvent`.
- Updated `FilesystemSettingsProvider` to use `path_description: None` when reporting global serialization errors, aligning with the `GlobalSettingsError` definition.
- Updated all relevant unit tests in `service_tests.rs` to reflect these changes, including new assertions for `SettingsLoaded` and `SettingsSaved` events and the handling of the `GlobalSettingsEvent` enum.