### PR TITLE
feat: Implement foundational Vulkan renderer modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "vulkan_renderer"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+vulkanalia = { version = "0.12.0", features = ["libloading", "window"] }
+raw-window-handle = "0.5"
+log = "0.4"
+image = "0.24"
+vk-mem-rs = "0.2.3" # Added as per error.rs, though not directly in instance.rs
+# Add other dependencies as needed by other modules
+[features]
+default = []

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,0 +1,136 @@
+use crate::error::{Result, VulkanError};
+use crate::instance::VulkanInstance;
+use crate::physical_device::PhysicalDeviceInfo;
+use crate::device::LogicalDevice; // Assuming Arc<Device> is accessible from LogicalDevice
+use std::sync::Arc;
+use vulkanalia::prelude::v1_0::*;
+use vk_mem_rs::{Allocator as VmaAllocator, AllocatorCreateInfo, Allocation, AllocationCreateInfo, MemoryUsage, AllocationCreateFlags};
+
+pub struct Allocator {
+    vma_allocator: VmaAllocator,
+    device: Arc<Device>, // Keep a reference to the device for destruction if VMA needs it implicitly
+}
+
+impl Allocator {
+    pub fn new(
+        instance_wrapper: &VulkanInstance,
+        physical_device_info: &PhysicalDeviceInfo,
+        logical_device_wrapper: &LogicalDevice,
+    ) -> Result<Self> {
+        let instance_ref: &Arc<Instance> = instance_wrapper.raw();
+        let physical_device = physical_device_info.raw();
+        let device_ref: &Arc<Device> = logical_device_wrapper.raw();
+        let device_clone_for_struct = device_ref.clone(); // Clone Arc for struct ownership
+
+        // For vk-mem-rs 0.2.3, we need to populate VulkanFunctions.
+        let vulkan_functions = vk_mem_rs::VulkanFunctions::new(
+            instance_wrapper.entry().static_fn(), // Entry static functions
+            instance_ref.static_fn(),             // Instance static functions
+            device_ref.static_fn(),               // Device static functions
+        );
+
+        // As per Rendering Vulkan.md (Section 4.1)
+        // preferredLargeHeapBlockSize: Empfohlen 256 MiB, oder heap_size / 8 für Heaps <= 1 GiB.
+        // VMA default is 256MB, so we can omit it or set it explicitly.
+        let create_info = AllocatorCreateInfo::new(
+            instance_ref,    // Pass &Arc<Instance>
+            device_ref,      // Pass &Arc<Device>
+            physical_device,
+        )
+        .set_vulkan_functions(vulkan_functions); // For vk-mem-rs 0.2.3
+        // .vulkan_api_version(vk::API_VERSION_1_3) // If needed by VMA version
+
+
+        let vma_allocator = VmaAllocator::new(create_info)
+            .map_err(VulkanError::VmaResult)?;
+        
+        log::info!("Vulkan Memory Allocator (VMA) initialized.");
+
+        Ok(Self { vma_allocator, device: device_clone_for_struct })
+    }
+
+    pub fn create_buffer(
+        &self,
+        buffer_info: &vk::BufferCreateInfo,
+        usage: MemoryUsage,
+        flags: Option<AllocationCreateFlags>, // e.g., MAPPED, HOST_ACCESS_SEQUENTIAL_WRITE
+    ) -> Result<(vk::Buffer, Allocation)> {
+        // Example: Prefer DEVICE_LOCAL | HOST_VISIBLE for UMA for dynamic data
+        // `usage` flag in AllocationCreateInfo helps VMA pick the right memory type.
+        // For UMA, CpuToGpu often results in DEVICE_LOCAL | HOST_VISIBLE.
+        // GpuOnly for static vertex/index buffers.
+        
+        let allocation_create_info = AllocationCreateInfo {
+            usage,
+            flags: flags.unwrap_or_else(AllocationCreateFlags::empty), // Default to no special flags
+            ..Default::default() // required_flags, preferred_flags, memory_type_bits, pool, user_data
+        };
+
+        self.vma_allocator
+            .create_buffer(buffer_info, &allocation_create_info)
+            .map_err(VulkanError::VmaResult)
+    }
+
+    pub fn create_image(
+        &self,
+        image_info: &vk::ImageCreateInfo,
+        usage: MemoryUsage, // Typically GpuOnly for textures, render targets
+        flags: Option<AllocationCreateFlags>,
+    ) -> Result<(vk::Image, Allocation)> {
+        let allocation_create_info = AllocationCreateInfo {
+            usage,
+            flags: flags.unwrap_or_else(AllocationCreateFlags::empty),
+            ..Default::default()
+        };
+        
+        self.vma_allocator
+            .create_image(image_info, &allocation_create_info)
+            .map_err(VulkanError::VmaResult)
+    }
+    
+    // It's important to destroy buffers/images created with VMA using VMA functions
+    pub fn destroy_buffer(&self, buffer: vk::Buffer, allocation: Allocation) -> Result<()> {
+        self.vma_allocator.destroy_buffer(buffer, allocation);
+        Ok(())
+    }
+
+    pub fn destroy_image(&self, image: vk::Image, allocation: Allocation) -> Result<()> {
+        self.vma_allocator.destroy_image(image, allocation);
+        Ok(())
+    }
+
+    // Map memory
+    pub fn map_memory(&self, allocation: &mut Allocation) -> Result<*mut u8> {
+        self.vma_allocator.map_memory(allocation).map_err(VulkanError::VmaResult)
+    }
+
+    // Unmap memory
+    pub fn unmap_memory(&self, allocation: &mut Allocation) -> Result<()> {
+        self.vma_allocator.unmap_memory(allocation); // This function is void in vk-mem-rs
+        Ok(())
+    }
+    
+    // Flush allocation (if not HOST_COHERENT and HOST_VISIBLE)
+    pub fn flush_allocation(&self, allocation: &Allocation, offset: vk::DeviceSize, size: vk::DeviceSize) -> Result<()> {
+        self.vma_allocator.flush_allocation(allocation, offset, size).map_err(VulkanError::VmaResult)
+    }
+    
+    // Invalidate allocation (if not HOST_COHERENT and HOST_VISIBLE)
+    pub fn invalidate_allocation(&self, allocation: &Allocation, offset: vk::DeviceSize, size: vk::DeviceSize) -> Result<()> {
+        self.vma_allocator.invalidate_allocation(allocation, offset, size).map_err(VulkanError::VmaResult)
+    }
+
+    // Getter for the raw VMA allocator if needed elsewhere (e.g. for stats or custom pools)
+    pub fn raw_vma(&self) -> &VmaAllocator {
+        &self.vma_allocator
+    }
+}
+
+impl Drop for Allocator {
+    fn drop(&mut self) {
+        // VMA allocator is destroyed when it goes out of scope.
+        // Its Drop trait handles cleanup.
+        // self.vma_allocator.destroy(); // Not needed if VmaAllocator implements Drop
+        log::debug!("VMA Allocator dropped, resources should be freed.");
+    }
+}

--- a/src/buffer_utils.rs
+++ b/src/buffer_utils.rs
@@ -1,0 +1,1 @@
+// TODO: Implement module

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,0 +1,141 @@
+use crate::error::{Result, VulkanError};
+use crate::instance::VulkanInstance;
+use crate::physical_device::{PhysicalDeviceInfo, QueueFamilyIndices};
+use std::collections::HashSet;
+use std::ffi::CStr;
+use std::sync::Arc;
+use vulkanalia::prelude::v1_0::*;
+
+// Required device extensions (as per physical_device.rs and Rendering Vulkan.md)
+use vulkanalia::vk::{KhrSwapchainExtension, ExtExternalMemoryDmaBufExtension, KhrExternalMemoryFdExtension, ExtImageDrmFormatModifierExtension};
+
+
+#[derive(Debug, Clone)]
+pub struct Queues {
+    pub graphics_queue: vk::Queue,
+    pub present_queue: vk::Queue, // May be the same as graphics_queue
+    pub compute_queue: Option<vk::Queue>, // Optional
+    pub transfer_queue: Option<vk::Queue>, // Optional, may be same as graphics or compute
+}
+
+pub struct LogicalDevice {
+    device: Arc<Device>,
+    queues: Queues,
+}
+
+impl LogicalDevice {
+    pub fn new(
+        instance_wrapper: &VulkanInstance,
+        physical_device_info: &PhysicalDeviceInfo,
+    ) -> Result<Self> {
+        let instance = instance_wrapper.raw();
+        let physical_device = physical_device_info.raw();
+        let indices = physical_device_info.queue_family_indices();
+
+        let mut unique_queue_families = HashSet::new();
+        unique_queue_families.insert(indices.graphics_family.unwrap());
+        unique_queue_families.insert(indices.present_family.unwrap());
+        if let Some(compute_family) = indices.compute_family {
+            unique_queue_families.insert(compute_family);
+        }
+        if let Some(transfer_family) = indices.transfer_family {
+            unique_queue_families.insert(transfer_family);
+        }
+
+        let queue_priority = 1.0;
+        let mut queue_create_infos = Vec::new();
+        for queue_family_index in unique_queue_families {
+            let info = vk::DeviceQueueCreateInfo::builder()
+                .queue_family_index(queue_family_index)
+                .queue_priorities(&[queue_priority]);
+            queue_create_infos.push(info);
+        }
+
+        // Specify required device features. Enable only what's needed and available.
+        let available_features = physical_device_info.features();
+        let mut features_to_enable = vk::PhysicalDeviceFeatures::builder();
+        if available_features.sampler_anisotropy == vk::TRUE {
+            features_to_enable = features_to_enable.sampler_anisotropy(true);
+        }
+        if available_features.geometry_shader == vk::TRUE {
+            // Enable if actually used by a pipeline later
+            // features_to_enable = features_to_enable.geometry_shader(true);
+        }
+        // Add other features as needed, e.g., for robustBufferAccess, tessellation shaders etc.
+        // features_to_enable = features_to_enable.robust_buffer_access(true);
+
+
+        let device_extensions_cptr = [
+            KhrSwapchainExtension::name().as_ptr(),
+            ExtExternalMemoryDmaBufExtension::name().as_ptr(),
+            KhrExternalMemoryFdExtension::name().as_ptr(),
+            ExtImageDrmFormatModifierExtension::name().as_ptr(),
+        ];
+        
+        // Check if all these extensions are actually supported by the selected physical device.
+        // This check should ideally be part of PhysicalDeviceInfo or done before this stage.
+        // For simplicity here, we assume PhysicalDeviceInfo already vetted them.
+
+        let mut device_create_info = vk::DeviceCreateInfo::builder()
+            .queue_create_infos(&queue_create_infos)
+            .enabled_features(&features_to_enable)
+            .enabled_extension_names(&device_extensions_cptr);
+
+        // For compatibility with older Vulkan versions or specific driver requirements,
+        // validation layers might be specified at device level too, but it's generally
+        // recommended at instance level. We'll assume instance-level for now.
+        // If validation layers are needed at device level:
+        // .enabled_layer_names(&validation_layers_cptr_if_any)
+
+        // Vulkan 1.3 features like dynamic_rendering and synchronization2
+        // are enabled via pNext chains if not part of core for the target API version.
+        // Assuming API_VERSION_1_3 was requested for the instance, these are core.
+        // If specific 1.1 or 1.2 features are needed and not core in 1.0, they go in pNext.
+        // e.g. let mut features12 = vk::PhysicalDeviceVulkan12Features::builder().timeline_semaphore(true);
+        // device_create_info = device_create_info.push_next(&mut features12);
+
+
+        let device = unsafe { instance.create_device(physical_device, &device_create_info, None) }
+            .map_err(VulkanError::VkResult)?;
+        let device = Arc::new(device);
+        log::info!("Logical device created.");
+
+        let graphics_queue = unsafe { device.get_device_queue(indices.graphics_family.unwrap(), 0) };
+        let present_queue = unsafe { device.get_device_queue(indices.present_family.unwrap(), 0) };
+        
+        let compute_queue = indices.compute_family.map(|idx| unsafe { device.get_device_queue(idx, 0) });
+        let transfer_queue = indices.transfer_family.map(|idx| unsafe { device.get_device_queue(idx, 0) });
+
+        log::info!("Retrieved device queues: Graphics, Present. Compute: {:?}, Transfer: {:?}",
+            compute_queue.is_some(), transfer_queue.is_some());
+
+        Ok(Self {
+            device,
+            queues: Queues {
+                graphics_queue,
+                present_queue,
+                compute_queue,
+                transfer_queue,
+            },
+        })
+    }
+
+    // Getter for the raw Vulkan device
+    pub fn raw(&self) -> &Arc<Device> {
+        &self.device
+    }
+    
+    // Getter for the queues
+    pub fn queues(&self) -> &Queues {
+        &self.queues
+    }
+}
+
+impl Drop for LogicalDevice {
+    fn drop(&mut self) {
+        unsafe { self.device.destroy_device(None) };
+        log::debug!("Logical device destroyed.");
+    }
+}
+
+```

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,124 @@
+use std::error::Error;
+use std::fmt;
+use std::io;
+
+use image;
+use vk_mem_rs;
+use vulkanalia;
+
+/// A specialized `Result` type for Vulkan operations.
+pub type Result<T> = std::result::Result<T, VulkanError>;
+
+/// The error type for Vulkan operations.
+#[derive(Debug)]
+pub enum VulkanError {
+    VkResult(vulkanalia::vk::Result),
+    VmaResult(vk_mem_rs::Error),
+    IoError(io::Error),
+    ImageError(image::ImageError),
+    Message(String),
+    PhysicalDeviceSelectionFailed,
+    QueueFamilyNotFound,
+    SwapchainCreationError(String),
+    PipelineLayoutCreationError(String),
+    PipelineCreationError(String),
+    ShaderModuleCreationError(String),
+    RenderPassCreationError(String),
+    FramebufferCreationError(String),
+    CommandPoolCreationError(String),
+    CommandBufferAllocationError(String),
+    DescriptorSetLayoutCreationError(String),
+    DescriptorPoolCreationError(String),
+    DescriptorSetAllocationError(String),
+    ImageViewCreationError(String),
+    SamplerCreationError(String),
+    FenceCreationError(String),
+    SemaphoreCreationError(String),
+    SurfaceCreationError(String),
+    DeviceLost,
+    SubmitError(String),
+    AcquireNextImageError(vulkanalia::vk::Result),
+    PresentError(vulkanalia::vk::Result),
+}
+
+impl fmt::Display for VulkanError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            VulkanError::VkResult(ref err) => write!(f, "Vulkan error: {}", err),
+            VulkanError::VmaResult(ref err) => write!(f, "VMA error: {}", err),
+            VulkanError::IoError(ref err) => write!(f, "IO error: {}", err),
+            VulkanError::ImageError(ref err) => write!(f, "Image error: {}", err),
+            VulkanError::Message(ref msg) => write!(f, "{}", msg),
+            VulkanError::PhysicalDeviceSelectionFailed => write!(f, "Physical device selection failed"),
+            VulkanError::QueueFamilyNotFound => write!(f, "Queue family not found"),
+            VulkanError::SwapchainCreationError(ref msg) => write!(f, "Swapchain creation error: {}", msg),
+            VulkanError::PipelineLayoutCreationError(ref msg) => write!(f, "Pipeline layout creation error: {}", msg),
+            VulkanError::PipelineCreationError(ref msg) => write!(f, "Pipeline creation error: {}", msg),
+            VulkanError::ShaderModuleCreationError(ref msg) => write!(f, "Shader module creation error: {}", msg),
+            VulkanError::RenderPassCreationError(ref msg) => write!(f, "Render pass creation error: {}", msg),
+            VulkanError::FramebufferCreationError(ref msg) => write!(f, "Framebuffer creation error: {}", msg),
+            VulkanError::CommandPoolCreationError(ref msg) => write!(f, "Command pool creation error: {}", msg),
+            VulkanError::CommandBufferAllocationError(ref msg) => write!(f, "Command buffer allocation error: {}", msg),
+            VulkanError::DescriptorSetLayoutCreationError(ref msg) => write!(f, "Descriptor set layout creation error: {}", msg),
+            VulkanError::DescriptorPoolCreationError(ref msg) => write!(f, "Descriptor pool creation error: {}", msg),
+            VulkanError::DescriptorSetAllocationError(ref msg) => write!(f, "Descriptor set allocation error: {}", msg),
+            VulkanError::ImageViewCreationError(ref msg) => write!(f, "Image view creation error: {}", msg),
+            VulkanError::SamplerCreationError(ref msg) => write!(f, "Sampler creation error: {}", msg),
+            VulkanError::FenceCreationError(ref msg) => write!(f, "Fence creation error: {}", msg),
+            VulkanError::SemaphoreCreationError(ref msg) => write!(f, "Semaphore creation error: {}", msg),
+            VulkanError::SurfaceCreationError(ref msg) => write!(f, "Surface creation error: {}", msg),
+            VulkanError::DeviceLost => write!(f, "Device lost"),
+            VulkanError::SubmitError(ref msg) => write!(f, "Submit error: {}", msg),
+            VulkanError::AcquireNextImageError(ref err) => write!(f, "Acquire next image error: {}", err),
+            VulkanError::PresentError(ref err) => write!(f, "Present error: {}", err),
+        }
+    }
+}
+
+impl Error for VulkanError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match *self {
+            VulkanError::VkResult(ref err) => Some(err),
+            VulkanError::VmaResult(ref err) => Some(err),
+            VulkanError::IoError(ref err) => Some(err),
+            VulkanError::ImageError(ref err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<vulkanalia::vk::Result> for VulkanError {
+    fn from(err: vulkanalia::vk::Result) -> VulkanError {
+        VulkanError::VkResult(err)
+    }
+}
+
+impl From<vk_mem_rs::Error> for VulkanError {
+    fn from(err: vk_mem_rs::Error) -> VulkanError {
+        VulkanError::VmaResult(err)
+    }
+}
+
+impl From<io::Error> for VulkanError {
+    fn from(err: io::Error) -> VulkanError {
+        VulkanError::IoError(err)
+    }
+}
+
+impl From<image::ImageError> for VulkanError {
+    fn from(err: image::ImageError) -> VulkanError {
+        VulkanError::ImageError(err)
+    }
+}
+
+impl From<String> for VulkanError {
+    fn from(msg: String) -> VulkanError {
+        VulkanError::Message(msg)
+    }
+}
+
+impl From<&str> for VulkanError {
+    fn from(msg: &str) -> VulkanError {
+        VulkanError::Message(msg.to_owned())
+    }
+}

--- a/src/frame_renderer.rs
+++ b/src/frame_renderer.rs
@@ -1,0 +1,1 @@
+// TODO: Implement module

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -1,0 +1,42 @@
+use crate::error::{Result, VulkanError};
+use crate::device::LogicalDevice;
+use std::sync::Arc; // Not strictly needed here, but good for consistency if Arc<Device> was stored.
+use vulkanalia::prelude::v1_0::*;
+
+// Function to create framebuffers.
+// This function is designed to be called when the swapchain is created or recreated.
+// The caller (e.g., FrameRenderer or SurfaceSwapchain) will manage the lifetime of these framebuffers.
+pub fn create_framebuffers(
+    logical_device_wrapper: &LogicalDevice,
+    swapchain_image_views: &[vk::ImageView],
+    depth_image_view: vk::ImageView, // The single depth image view
+    render_pass: vk::RenderPass,
+    swapchain_extent: vk::Extent2D,
+) -> Result<Vec<vk::Framebuffer>> {
+    let device = logical_device_wrapper.raw();
+
+    swapchain_image_views
+        .iter()
+        .map(|&color_image_view| {
+            // The order of attachments must match the order of attachment descriptions
+            // in the render pass (color attachment at index 0, depth at index 1).
+            let attachments = &[color_image_view, depth_image_view]; 
+
+            let framebuffer_info = vk::FramebufferCreateInfo::builder()
+                .render_pass(render_pass)
+                .attachments(attachments)
+                .width(swapchain_extent.width)
+                .height(swapchain_extent.height)
+                .layers(1);
+
+            unsafe { device.create_framebuffer(&framebuffer_info, None) }
+                .map_err(VulkanError::VkResult)
+        })
+        .collect::<std::result::Result<Vec<_>, _>>() // Collect into Result<Vec<Framebuffer>, VulkanError>
+}
+
+// Note: Framebuffer destruction is not handled in this module directly.
+// The owner of the framebuffers (likely FrameRenderer or a component managing swapchain resources)
+// will be responsible for iterating through the Vec<vk::Framebuffer> and calling
+// `device.destroy_framebuffer(framebuffer, None)` when they are no longer needed
+// (e.g., during swapchain recreation or application shutdown).

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1,0 +1,162 @@
+use crate::error::{Result, VulkanError};
+use std::ffi::{c_char, CStr, CString};
+use std::os::raw::c_void;
+use std::sync::Arc;
+use vulkanalia::loader::{LibloadingLoader, LIBRARY};
+use vulkanalia::prelude::v1_0::*;
+use vulkanalia::window as vk_window;
+use vulkanalia::vk::{ExtDebugUtilsExtension, KhrSurfaceExtension, KhrWaylandSurfaceExtension};
+
+// Optional: For portability, though Wayland is primary
+#[cfg(target_os = "macos")]
+use vulkanalia::vk::KhrPortabilityEnumerationExtension;
+
+
+// Define a struct to hold the Vulkan entry points, instance, and debug messenger.
+pub struct VulkanInstance {
+    entry: Entry,
+    instance: Arc<Instance>,
+    debug_messenger: Option<vk::DebugUtilsMessengerEXT>,
+}
+
+impl VulkanInstance {
+    pub fn new(window_title: &str, enable_validation_layers: bool) -> Result<Self> {
+        let loader = unsafe { LibloadingLoader::new(LIBRARY) }
+            .map_err(|e| VulkanError::Message(format!("Failed to load Vulkan library: {}", e)))?;
+        let entry = Entry::new(loader).map_err(|e| VulkanError::Message(format!("Failed to create Vulkan entry: {}", e)))?;
+
+        let application_name = CString::new(window_title).unwrap();
+        let engine_name = CString::new("NovaDE Renderer").unwrap();
+
+        let app_info = vk::ApplicationInfo::builder()
+            .application_name(&application_name)
+            .application_version(vk::make_version(1, 0, 0))
+            .engine_name(&engine_name)
+            .engine_version(vk::make_version(1, 0, 0))
+            .api_version(vk::API_VERSION_1_3); // As per Rendering Vulkan.md
+
+        let mut layers = Vec::new();
+        if enable_validation_layers {
+            layers.push(CString::new("VK_LAYER_KHRONOS_validation").unwrap().as_ptr());
+        }
+
+        // Check for layer support
+        if enable_validation_layers && !Self::check_validation_layer_support(&entry, &layers)? {
+            return Err(VulkanError::Message("Validation layers requested, but not available!".to_string()));
+        }
+
+        let mut extensions = vec![
+            KhrSurfaceExtension::name().as_ptr(),
+            KhrWaylandSurfaceExtension::name().as_ptr(), // For Wayland
+            ExtDebugUtilsExtension::name().as_ptr(),
+        ];
+
+        // For macOS portability, if needed, though target is Linux/Wayland
+        #[cfg(target_os = "macos")]
+        {
+            extensions.push(KhrPortabilityEnumerationExtension::name().as_ptr());
+        }
+
+
+        let mut instance_create_info = vk::InstanceCreateInfo::builder()
+            .application_info(&app_info)
+            .enabled_layer_names(&layers)
+            .enabled_extension_names(&extensions);
+
+        // Handle portability flags for macOS
+        #[cfg(target_os = "macos")]
+        {
+            instance_create_info = instance_create_info.flags(vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR);
+        }
+
+
+        let instance = unsafe { entry.create_instance(&instance_create_info, None) }
+            .map_err(|e| VulkanError::VkResult(e))?;
+        let instance = Arc::new(instance);
+
+        let debug_messenger = if enable_validation_layers {
+            let messenger_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+                .message_severity(
+                    vk::DebugUtilsMessageSeverityFlagsEXT::ERROR
+                        | vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
+                        // | vk::DebugUtilsMessageSeverityFlagsEXT::INFO // Optional
+                        // | vk::DebugUtilsMessageSeverityFlagsEXT::VERBOSE, // Optional
+                )
+                .message_type(
+                    vk::DebugUtilsMessageTypeFlagsEXT::GENERAL
+                        | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION
+                        | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE,
+                )
+                .user_callback(Some(vulkan_debug_callback));
+
+            Some(unsafe { instance.create_debug_utils_messenger_ext(&messenger_info, None) }
+                .map_err(|e| VulkanError::VkResult(e))?)
+        } else {
+            None
+        };
+        
+        log::info!("Vulkan Instance created successfully.");
+        if enable_validation_layers {
+            log::info!("Validation layers enabled.");
+        }
+
+
+        Ok(Self { entry, instance, debug_messenger })
+    }
+
+    fn check_validation_layer_support(entry: &Entry, layers_cchar: &[*const c_char]) -> Result<bool> {
+        let available_layers = unsafe { entry.enumerate_instance_layer_properties() }
+            .map_err(|e| VulkanError::VkResult(e))?
+            .iter()
+            .map(|l| unsafe { CStr::from_ptr(l.layer_name.as_ptr()) })
+            .collect::<Vec<_>>();
+
+        for required_layer_ptr in layers_cchar {
+            let required_layer_name = unsafe { CStr::from_ptr(*required_layer_ptr) };
+            if !available_layers.contains(&required_layer_name) {
+                log::warn!("Validation layer not available: {:?}", required_layer_name);
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+    
+    // Getter for the raw Vulkan instance
+    pub fn raw(&self) -> &Arc<Instance> {
+        &self.instance
+    }
+
+    // Getter for the entry points
+    pub fn entry(&self) -> &Entry {
+        &self.entry
+    }
+}
+
+impl Drop for VulkanInstance {
+    fn drop(&mut self) {
+        if let Some(messenger) = self.debug_messenger {
+            unsafe { self.instance.destroy_debug_utils_messenger_ext(messenger, None) };
+            log::debug!("Debug messenger destroyed.");
+        }
+        unsafe { self.instance.destroy_instance(None) };
+        log::debug!("Vulkan instance destroyed.");
+    }
+}
+
+// Debug callback function
+unsafe extern "system" fn vulkan_debug_callback(
+    message_severity: vk::DebugUtilsMessageSeverityFlagsEXT,
+    message_type: vk::DebugUtilsMessageTypeFlagsEXT,
+    data: *const vk::DebugUtilsMessengerCallbackDataEXT,
+    _user_data: *mut c_void,
+) -> vk::Bool32 {
+    let message = CStr::from_ptr((*data).message).to_string_lossy();
+    match message_severity {
+        vk::DebugUtilsMessageSeverityFlagsEXT::ERROR => log::error!("[VULKAN VALIDATION] ({:?}): {}", message_type, message),
+        vk::DebugUtilsMessageSeverityFlagsEXT::WARNING => log::warn!("[VULKAN VALIDATION] ({:?}): {}", message_type, message),
+        vk::DebugUtilsMessageSeverityFlagsEXT::INFO => log::info!("[VULKAN VALIDATION] ({:?}): {}", message_type, message),
+        vk::DebugUtilsMessageSeverityFlagsEXT::VERBOSE => log::trace!("[VULKAN VALIDATION] ({:?}): {}", message_type, message),
+        _ => log::info!("[VULKAN VALIDATION] ({:?}): {}", message_type, message),
+    }
+    vk::FALSE // Do not abort the Vulkan call that triggered the callback
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,15 @@
+pub mod allocator;
+pub mod buffer_utils;
+pub mod device;
+pub mod error;
+pub mod framebuffer;
+pub mod frame_renderer;
+pub mod instance;
+pub mod physical_device;
+pub mod pipeline;
+pub mod render_pass;
+pub mod surface_swapchain;
+pub mod sync_primitives;
+pub mod texture;
+
+pub use error::{Result, VulkanError};

--- a/src/physical_device.rs
+++ b/src/physical_device.rs
@@ -1,0 +1,345 @@
+use crate::error::{Result, VulkanError};
+use crate::instance::VulkanInstance; // To access the VulkanInstance
+use std::collections::HashSet;
+use std::ffi::CStr;
+use std::sync::Arc; // To hold VulkanInstance
+use vulkanalia::prelude::v1_0::*;
+use vulkanalia::vk::{KhrSurfaceExtension, KhrSwapchainExtension, KhrWaylandSurfaceExtension};
+
+// For DMA-BUF extensions, as per Rendering Vulkan.md
+use vulkanalia::vk::{ExtExternalMemoryDmaBufExtension, KhrExternalMemoryFdExtension, ExtImageDrmFormatModifierExtension};
+
+
+// Struct to hold queue family indices
+#[derive(Debug, Default, Clone, Copy)]
+pub struct QueueFamilyIndices {
+    pub graphics_family: Option<u32>,
+    pub present_family: Option<u32>,
+    pub compute_family: Option<u32>,
+    pub transfer_family: Option<u32>,
+}
+
+impl QueueFamilyIndices {
+    pub fn is_complete_for_graphics_present(&self) -> bool {
+        self.graphics_family.is_some() && self.present_family.is_some()
+    }
+}
+
+// Struct to hold swapchain support details
+#[derive(Debug, Clone)]
+pub struct SwapChainSupportDetails {
+    pub capabilities: vk::SurfaceCapabilitiesKHR,
+    pub formats: Vec<vk::SurfaceFormatKHR>,
+    pub present_modes: Vec<vk::PresentModeKHR>,
+}
+
+// Main struct for this module
+pub struct PhysicalDeviceInfo {
+    physical_device: vk::PhysicalDevice,
+    properties: vk::PhysicalDeviceProperties,
+    features: vk::PhysicalDeviceFeatures,
+    queue_family_indices: QueueFamilyIndices,
+    // Swapchain support details are queried here but might be more relevant when a surface exists.
+    // For now, we ensure the device *can* support a swapchain via extension check.
+    // Specific surface support details will be checked by surface_swapchain.rs
+}
+
+impl PhysicalDeviceInfo {
+    pub fn new(
+        instance_wrapper: &VulkanInstance,
+        surface: vk::SurfaceKHR, // Needed to check presentation support
+        wayland_display: *mut std::ffi::c_void, // For vkGetPhysicalDeviceWaylandPresentationSupportKHR
+    ) -> Result<Self> {
+        let instance = instance_wrapper.raw();
+        let physical_devices = unsafe { instance.enumerate_physical_devices() }
+            .map_err(VulkanError::VkResult)?
+            .into_iter()
+            .filter_map(|pd| {
+                let score = Self::score_device(instance, pd, surface, wayland_display);
+                if score > 0 {
+                    Some((score, pd))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let physical_device = physical_devices
+            .into_iter()
+            .max_by_key(|(score, _)| *score)
+            .map(|(_, pd)| pd)
+            .ok_or(VulkanError::PhysicalDeviceSelectionFailed)?;
+
+        let properties = unsafe { instance.get_physical_device_properties(physical_device) };
+        let features = unsafe { instance.get_physical_device_features(physical_device) };
+        let queue_family_indices = Self::find_queue_families(instance, physical_device, surface, wayland_display)?;
+
+        log::info!("Selected physical device: {}", unsafe {
+            CStr::from_ptr(properties.device_name.as_ptr()).to_string_lossy()
+        });
+        log::info!("Device type: {:?}", properties.device_type);
+        log::info!("Queue families: {:?}", queue_family_indices);
+
+        Ok(Self {
+            physical_device,
+            properties,
+            features,
+            queue_family_indices,
+        })
+    }
+
+    fn score_device(
+        instance: &Arc<Instance>,
+        physical_device: vk::PhysicalDevice,
+        surface: vk::SurfaceKHR,
+        wayland_display: *mut std::ffi::c_void,
+    ) -> i32 {
+        let properties = unsafe { instance.get_physical_device_properties(physical_device) };
+        let features = unsafe { instance.get_physical_device_features(physical_device) };
+
+        let required_extensions = [
+            KhrSwapchainExtension::name(),
+            // DMA-BUF related extensions from Rendering Vulkan.md (Section 3.2 & 3.4)
+            ExtExternalMemoryDmaBufExtension::name(),
+            KhrExternalMemoryFdExtension::name(),
+            ExtImageDrmFormatModifierExtension::name(),
+        ];
+
+        if !Self::check_device_extension_support(instance, physical_device, &required_extensions) {
+            log::debug!(
+                "Device {} does not support required extensions.",
+                unsafe { CStr::from_ptr(properties.device_name.as_ptr()).to_string_lossy() }
+            );
+            return 0; // Essential extensions not supported
+        }
+
+        let indices = match Self::find_queue_families(instance, physical_device, surface, wayland_display) {
+            Ok(i) => i,
+            Err(_) => {
+                log::debug!(
+                    "Could not find required queue families for device {}.",
+                    unsafe { CStr::from_ptr(properties.device_name.as_ptr()).to_string_lossy() }
+                );
+                return 0; // Could not find required queue families
+            }
+        };
+
+        if !indices.is_complete_for_graphics_present() {
+            log::debug!(
+                "Device {} does not have complete graphics/present queues.",
+                unsafe { CStr::from_ptr(properties.device_name.as_ptr()).to_string_lossy() }
+            );
+            return 0; // Graphics or present queue not found
+        }
+        
+        // Check for basic swapchain support (at least one format and present mode)
+        // More detailed check will be in surface_swapchain.rs
+        let support = match Self::query_swap_chain_support_internal(instance, physical_device, surface) {
+            Ok(s) => s,
+            Err(_) => {
+                log::debug!(
+                    "Device {} does not support swapchain (internal query failed).",
+                    unsafe { CStr::from_ptr(properties.device_name.as_ptr()).to_string_lossy() }
+                );
+                return 0;
+            }
+        };
+        if support.formats.is_empty() || support.present_modes.is_empty() {
+            log::debug!(
+                "Device {} has no available swapchain formats or present modes.",
+                unsafe { CStr::from_ptr(properties.device_name.as_ptr()).to_string_lossy() }
+            );
+            return 0;
+        }
+
+
+        let mut score = 0;
+
+        // Prioritize integrated GPU as per documentation (UMA target)
+        if properties.device_type == vk::PhysicalDeviceType::INTEGRATED_GPU {
+            score += 1000;
+        } else if properties.device_type == vk::PhysicalDeviceType::DISCRETE_GPU {
+            score += 500;
+        }
+        
+        // API version (prefer 1.3 as per Rendering Vulkan.md)
+        if properties.api_version >= vk::API_VERSION_1_3 {
+            score += 200;
+        }
+
+
+        // Prefer devices with samplerAnisotropy
+        if features.sampler_anisotropy != vk::FALSE {
+            score += 100;
+        }
+        
+        // Add more scoring based on limits or other features if needed
+        score += properties.limits.max_image_dimension2d / 100;
+        
+        log::debug!(
+            "Device {} scored: {}",
+            unsafe { CStr::from_ptr(properties.device_name.as_ptr()).to_string_lossy() },
+            score
+        );
+        score
+    }
+
+    fn check_device_extension_support(
+        instance: &Arc<Instance>,
+        physical_device: vk::PhysicalDevice,
+        required_extensions_cptr: &[&CStr],
+    ) -> bool {
+        let available_extensions = match unsafe {
+            instance.enumerate_device_extension_properties(physical_device, None)
+        } {
+            Ok(ext) => ext,
+            Err(e) => {
+                log::error!("Failed to enumerate device extensions: {}", e);
+                return false;
+            }
+        };
+
+        let mut available_set = HashSet::new();
+        for ext_prop in available_extensions {
+            available_set.insert(unsafe { CStr::from_ptr(ext_prop.extension_name.as_ptr()) });
+        }
+
+        for required_ext_name in required_extensions_cptr {
+            if !available_set.contains(required_ext_name) {
+                log::warn!("Physical device missing required extension: {:?}", required_ext_name);
+                return false;
+            }
+        }
+        true
+    }
+
+    fn find_queue_families(
+        instance: &Arc<Instance>,
+        physical_device: vk::PhysicalDevice,
+        surface: vk::SurfaceKHR,
+        wayland_display: *mut std::ffi::c_void, // Raw pointer from Smithay/Wayland
+    ) -> Result<QueueFamilyIndices> {
+        let mut indices = QueueFamilyIndices::default();
+        let queue_family_properties = unsafe {
+            instance.get_physical_device_queue_family_properties(physical_device)
+        };
+
+        for (i, properties) in queue_family_properties.iter().enumerate() {
+            let i = i as u32;
+
+            if properties.queue_flags.contains(vk::QueueFlags::GRAPHICS) {
+                indices.graphics_family = Some(i);
+            }
+
+            if properties.queue_flags.contains(vk::QueueFlags::COMPUTE) {
+                indices.compute_family = Some(i);
+            }
+            
+            if properties.queue_flags.contains(vk::QueueFlags::TRANSFER) {
+                // Prefer a dedicated transfer queue if it's not also graphics or compute
+                if !properties.queue_flags.contains(vk::QueueFlags::GRAPHICS) &&
+                   !properties.queue_flags.contains(vk::QueueFlags::COMPUTE) {
+                    if indices.transfer_family.is_none() { // Take the first dedicated one
+                        indices.transfer_family = Some(i);
+                    }
+                } else if indices.transfer_family.is_none() { // Or take any transfer queue if no dedicated one is found yet
+                     indices.transfer_family = Some(i);
+                }
+            }
+
+            // Check for Wayland presentation support
+            // This requires the KhrWaylandSurfaceExtension to be loaded by the Instance.
+            // The `wayland_display` pointer is platform specific.
+            // The actual type for `wayland_display` in vulkanalia is `*mut wl_display`
+            // which is often `*mut wayland_client::sys::client::wl_display`.
+            // Since we receive `*mut c_void`, we cast it.
+            let present_support = unsafe {
+                instance.get_physical_device_wayland_presentation_support_khr(
+                    physical_device,
+                    i,
+                    wayland_display as *mut _, // Cast to vulkanalia's expected wayland display type
+                )
+            } == vk::TRUE;
+            
+            if present_support {
+                indices.present_family = Some(i);
+            }
+        }
+        
+        // If no dedicated transfer queue was found, it can often share the graphics or compute queue
+        if indices.transfer_family.is_none() {
+            if indices.graphics_family.is_some() { // Graphics queues usually support transfer
+                indices.transfer_family = indices.graphics_family;
+            } else if indices.compute_family.is_some() { // Compute queues also usually support transfer
+                indices.transfer_family = indices.compute_family;
+            }
+        }
+
+
+        if indices.is_complete_for_graphics_present() {
+            Ok(indices)
+        } else {
+            Err(VulkanError::QueueFamilyNotFound)
+        }
+    }
+    
+    // Helper function to query swap chain support, used internally for scoring.
+    // A more public version might be in surface_swapchain.rs or passed from there.
+    fn query_swap_chain_support_internal(
+        instance: &Arc<Instance>,
+        physical_device: vk::PhysicalDevice,
+        surface: vk::SurfaceKHR,
+    ) -> Result<SwapChainSupportDetails> {
+        let capabilities = unsafe {
+            instance.get_physical_device_surface_capabilities_khr(physical_device, surface)
+        }.map_err(VulkanError::VkResult)?;
+
+        let formats = unsafe {
+            instance.get_physical_device_surface_formats_khr(physical_device, surface, None)
+        }.map_err(VulkanError::VkResult)?;
+
+        let present_modes = unsafe {
+            instance.get_physical_device_surface_present_modes_khr(physical_device, surface, None)
+        }.map_err(VulkanError::VkResult)?;
+        
+        Ok(SwapChainSupportDetails {
+            capabilities,
+            formats,
+            present_modes,
+        })
+    }
+
+    // Getters
+    pub fn raw(&self) -> vk::PhysicalDevice {
+        self.physical_device
+    }
+
+    pub fn properties(&self) -> &vk::PhysicalDeviceProperties {
+        &self.properties
+    }
+    
+    pub fn features(&self) -> &vk::PhysicalDeviceFeatures {
+        &self.features
+    }
+
+    pub fn queue_family_indices(&self) -> QueueFamilyIndices {
+        self.queue_family_indices
+    }
+}
+
+// Note: The `wayland_display` parameter in `new` and `find_queue_families`
+// is a raw pointer (`*mut std::ffi::c_void`). This is typical for FFI with Wayland.
+// Smithay or a similar library would provide this pointer.
+// For `get_physical_device_wayland_presentation_support_khr`, vulkanalia expects
+// `*mut wl_display` from the `wayland_sys` crate if you were using that directly.
+// Casting `*mut c_void` to `*mut wayland_sys::client::wl_display` might be needed
+// if using stricter types, but for the FFI call itself `*mut c_void` is often acceptable
+// if the underlying function signature in the Vulkan loader expects that.
+// Here, vulkanalia's generated wrapper for `vkGetPhysicalDeviceWaylandPresentationSupportKHR`
+// likely expects a specific pointer type from `wayland-client` or similar,
+// so a cast `wayland_display as *mut wayland_client::sys::client::wl_display`
+// might be needed if `vulkanalia` is compiled with `wayland-client` feature.
+// For now, `*mut _` is used as a placeholder for the correct Wayland display pointer type
+// that vulkanalia's wrapper expects. This might need adjustment based on the exact
+// Wayland binding crate used in the broader project.
+// The `KhrWaylandSurfaceExtension` must be enabled on the instance.

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,0 +1,1 @@
+// TODO: Implement module

--- a/src/render_pass.rs
+++ b/src/render_pass.rs
@@ -1,0 +1,133 @@
+use crate::error::{Result, VulkanError};
+use crate::device::LogicalDevice;
+use crate::instance::VulkanInstance; // Needed for find_supported_format
+use crate::physical_device::PhysicalDeviceInfo; // Needed for find_supported_format indirectly
+use std::sync::Arc;
+use vulkanalia::prelude::v1_0::*;
+
+pub struct RenderPass {
+    device: Arc<Device>,
+    render_pass: vk::RenderPass,
+}
+
+impl RenderPass {
+    pub fn new(
+        instance_wrapper: &VulkanInstance, // For physical device properties
+        physical_device_info: &PhysicalDeviceInfo, // For physical device handle
+        logical_device_wrapper: &LogicalDevice,
+        swapchain_format: vk::Format,
+    ) -> Result<Self> {
+        let device = logical_device_wrapper.raw().clone();
+        let physical_device = physical_device_info.raw(); // Get the raw physical device
+        let instance = instance_wrapper.raw(); // Get the raw instance for format properties
+
+        // 1. Color Attachment Description
+        let color_attachment = vk::AttachmentDescription::builder()
+            .format(swapchain_format)
+            .samples(vk::SampleCountFlags::_1)
+            .load_op(vk::AttachmentLoadOp::CLEAR)
+            .store_op(vk::AttachmentStoreOp::STORE)
+            .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
+            .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
+            .initial_layout(vk::ImageLayout::UNDEFINED)
+            .final_layout(vk::ImageLayout::PRESENT_SRC_KHR); // Ready for presentation
+
+        // 2. Depth Attachment Description
+        let depth_format = Self::find_depth_format(instance.instance(), physical_device)?; // Pass &Instance
+        let depth_attachment = vk::AttachmentDescription::builder()
+            .format(depth_format)
+            .samples(vk::SampleCountFlags::_1)
+            .load_op(vk::AttachmentLoadOp::CLEAR)
+            .store_op(vk::AttachmentStoreOp::DONT_CARE) // We don't need to store depth after this pass (for now)
+            .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
+            .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
+            .initial_layout(vk::ImageLayout::UNDEFINED)
+            .final_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+
+        // 3. Attachment References
+        let color_attachment_ref = vk::AttachmentReference::builder()
+            .attachment(0) // Index in the attachments array
+            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL);
+
+        let depth_attachment_ref = vk::AttachmentReference::builder()
+            .attachment(1) // Index in the attachments array
+            .layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+
+        // 4. Subpass Description
+        let subpass = vk::SubpassDescription::builder()
+            .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS)
+            .color_attachments(std::slice::from_ref(&color_attachment_ref))
+            .depth_stencil_attachment(&depth_attachment_ref); // Set depth attachment
+
+        // 5. Subpass Dependencies
+        // This dependency ensures that the image layout transitions happen correctly
+        // before and after the render pass.
+        let dependency = vk::SubpassDependency::builder()
+            .src_subpass(vk::SUBPASS_EXTERNAL) // Implicit subpass before render pass
+            .dst_subpass(0)                   // Our subpass (index 0)
+            .src_stage_mask(
+                vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT | // Wait for color output stage
+                vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS     // Or early fragment tests for depth
+            )
+            .src_access_mask(vk::AccessFlags::empty()) // No specific access from src needed if clearing
+            .dst_stage_mask(
+                vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT | // Operations in our subpass
+                vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS
+            )
+            .dst_access_mask(
+                vk::AccessFlags::COLOR_ATTACHMENT_WRITE |        // We will write to color attachment
+                vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE  // And depth attachment
+            );
+            // Note: More dependencies might be needed for complex scenarios or if PRESENT_SRC_KHR
+            // transition isn't handled by this single dependency or by swapchain image ownership transfers.
+            // For now, this covers the transition to a writable state.
+            // The finalLayout of attachments handles the transition out of the render pass.
+
+        let attachments = &[color_attachment, depth_attachment];
+        let render_pass_info = vk::RenderPassCreateInfo::builder()
+            .attachments(attachments)
+            .subpasses(std::slice::from_ref(&subpass))
+            .dependencies(std::slice::from_ref(&dependency));
+
+        let render_pass = unsafe { device.create_render_pass(&render_pass_info, None) }
+            .map_err(VulkanError::VkResult)?;
+        
+        log::info!("Basic render pass created with color and depth attachments.");
+
+        Ok(Self { device, render_pass })
+    }
+
+    // Helper to find a supported depth format
+    fn find_depth_format(
+        instance: &Instance,
+        physical_device: vk::PhysicalDevice,
+    ) -> Result<vk::Format> {
+        let candidates = vec![
+            vk::Format::D32_SFLOAT,
+            vk::Format::D32_SFLOAT_S8_UINT, // If stencil is needed later
+            vk::Format::D24_UNORM_S8_UINT,
+        ];
+
+        for format in candidates {
+            let properties = unsafe {
+                instance.get_physical_device_format_properties(physical_device, format)
+            };
+            // Check for optimal tiling features for depth attachment
+            if properties.optimal_tiling_features.contains(vk::FormatFeatureFlags::DEPTH_STENCIL_ATTACHMENT) {
+                return Ok(format);
+            }
+        }
+        Err(VulkanError::Message("Failed to find suitable depth format.".to_string()))
+    }
+
+    pub fn raw(&self) -> vk::RenderPass {
+        self.render_pass
+    }
+}
+
+impl Drop for RenderPass {
+    fn drop(&mut self) {
+        unsafe { self.device.destroy_render_pass(self.render_pass, None) };
+        log::debug!("Render pass destroyed.");
+    }
+}

--- a/src/surface_swapchain.rs
+++ b/src/surface_swapchain.rs
@@ -1,0 +1,327 @@
+use crate::error::{Result, VulkanError};
+use crate::instance::VulkanInstance;
+use crate::physical_device::{PhysicalDeviceInfo, QueueFamilyIndices, SwapChainSupportDetails};
+use crate::device::LogicalDevice;
+use std::sync::Arc;
+use vulkanalia::prelude::v1_0::*;
+use vulkanalia::window as vk_window; // For create_surface
+
+// These are raw pointers obtained from Smithay or a similar Wayland integration.
+// They are opaque handles to Wayland objects.
+pub type WaylandDisplayPtr = *mut std::ffi::c_void;
+pub type WaylandSurfacePtr = *mut std::ffi::c_void;
+
+pub struct SurfaceSwapchain {
+    instance: Arc<Instance>, // To destroy surface
+    device: Arc<Device>,     // To destroy swapchain and image views
+    
+    surface: vk::SurfaceKHR,
+    swapchain: vk::SwapchainKHR,
+    
+    images: Vec<vk::Image>,
+    image_views: Vec<vk::ImageView>,
+    
+    format: vk::Format,
+    extent: vk::Extent2D,
+
+    // Keep physical_device_info and queue_indices for recreation
+    physical_device: vk::PhysicalDevice, // No Arc needed, it's just a handle
+    queue_indices: QueueFamilyIndices,
+    wayland_display: WaylandDisplayPtr,
+    wayland_surface_ptr: WaylandSurfacePtr, // The wl_surface pointer for recreation
+}
+
+impl SurfaceSwapchain {
+    pub fn new(
+        instance_wrapper: &VulkanInstance,
+        physical_device_info: &PhysicalDeviceInfo,
+        logical_device_wrapper: &LogicalDevice,
+        wayland_display: WaylandDisplayPtr,    // e.g., from smithay::reexports::client::wl_display
+        wayland_surface_ptr: WaylandSurfacePtr, // e.g., from smithay::reexports::client::wl_surface
+        preferred_width: u32,
+        preferred_height: u32,
+    ) -> Result<Self> {
+        let instance = instance_wrapper.raw().clone();
+        let physical_device_handle = physical_device_info.raw(); // Renamed to avoid conflict
+        let device = logical_device_wrapper.raw().clone();
+        let queue_indices = physical_device_info.queue_family_indices();
+
+        // 1. Create Surface
+        // The `wayland_display` and `wayland_surface_ptr` are crucial here.
+        // `vulkanalia::window::create_surface` handles the platform-specific call.
+        let surface = unsafe {
+            vk_window::create_surface(
+                &instance,
+                wayland_display as *mut _, // Casts might be needed depending on exact types
+                wayland_surface_ptr as *mut _,
+                None,
+            )
+        }
+        .map_err(VulkanError::VkResult)?;
+        log::info!("Vulkan surface created for Wayland window.");
+
+        // Verify presentation support for the chosen graphics queue family on this new surface
+        // This was partially checked in PhysicalDeviceInfo, but this is the definitive check.
+        let present_support = unsafe {
+            instance.get_physical_device_surface_support_khr(
+                physical_device_handle, // Use renamed variable
+                queue_indices.present_family.ok_or(VulkanError::QueueFamilyNotFound)?,
+                surface,
+            )
+        } .map_err(VulkanError::VkResult)?;
+        if present_support != vk::TRUE {
+            return Err(VulkanError::Message("Selected queue family does not support presentation to this surface.".to_string()));
+        }
+
+
+        // 2. Create Swapchain (initial creation)
+        let (swapchain, format, extent, images) = Self::create_swapchain_internal(
+            &instance,
+            physical_device_handle, // Use renamed variable
+            &device,
+            surface,
+            queue_indices,
+            Some((preferred_width, preferred_height)), // Initial preferred dimensions
+            None, // old_swapchain
+        )?;
+
+        // 3. Create Image Views
+        let image_views = Self::create_image_views_internal(&device, &images, format)?;
+        
+        log::info!("Swapchain created with format {:?} and extent {}x{}", format, extent.width, extent.height);
+
+        Ok(Self {
+            instance,
+            device,
+            surface,
+            swapchain,
+            images,
+            image_views,
+            format,
+            extent,
+            physical_device: physical_device_handle, // Store the handle
+            queue_indices,
+            wayland_display,
+            wayland_surface_ptr,
+        })
+    }
+
+    fn query_support(
+        instance: &Instance,
+        physical_device: vk::PhysicalDevice,
+        surface: vk::SurfaceKHR,
+    ) -> Result<SwapChainSupportDetails> {
+        let capabilities = unsafe {
+            instance.get_physical_device_surface_capabilities_khr(physical_device, surface)
+        }.map_err(VulkanError::VkResult)?;
+        let formats = unsafe {
+            instance.get_physical_device_surface_formats_khr(physical_device, surface, None)
+        }.map_err(VulkanError::VkResult)?;
+        let present_modes = unsafe {
+            instance.get_physical_device_surface_present_modes_khr(physical_device, surface, None)
+        }.map_err(VulkanError::VkResult)?;
+        Ok(SwapChainSupportDetails { capabilities, formats, present_modes })
+    }
+    
+    fn choose_surface_format(available_formats: &[vk::SurfaceFormatKHR]) -> vk::SurfaceFormatKHR {
+        available_formats
+            .iter()
+            .find(|f| {
+                f.format == vk::Format::B8G8R8A8_SRGB // As per Rendering Vulkan.md
+                    && f.color_space == vk::ColorSpaceKHR::SRGB_NONLINEAR
+            })
+            .cloned()
+            .unwrap_or_else(|| available_formats[0]) // Fallback to the first available
+    }
+
+    fn choose_present_mode(available_present_modes: &[vk::PresentModeKHR]) -> vk::PresentModeKHR {
+        // As per Rendering Vulkan.md (Section 5.2) and general best practices
+        if available_present_modes.contains(&vk::PresentModeKHR::MAILBOX) {
+            vk::PresentModeKHR::MAILBOX // Good for low latency
+        } else if available_present_modes.contains(&vk::PresentModeKHR::FIFO_RELAXED) {
+            vk::PresentModeKHR::FIFO_RELAXED // V-Sync, but allows tearing if app is late
+        } else {
+            vk::PresentModeKHR::FIFO // Standard V-Sync (guaranteed to be available)
+        }
+    }
+
+    fn choose_extent(
+        capabilities: &vk::SurfaceCapabilitiesKHR,
+        preferred_width: u32,
+        preferred_height: u32,
+    ) -> vk::Extent2D {
+        if capabilities.current_extent.width != u32::MAX {
+            capabilities.current_extent // Window system dictates extent
+        } else {
+            vk::Extent2D::builder()
+                .width(preferred_width.clamp(
+                    capabilities.min_image_extent.width,
+                    capabilities.max_image_extent.width,
+                ))
+                .height(preferred_height.clamp(
+                    capabilities.min_image_extent.height,
+                    capabilities.max_image_extent.height,
+                ))
+                .build()
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)] // This function has many arguments by necessity for swapchain creation
+    fn create_swapchain_internal(
+        instance: &Instance,
+        physical_device: vk::PhysicalDevice,
+        device: &Device,
+        surface: vk::SurfaceKHR,
+        indices: QueueFamilyIndices,
+        preferred_dimensions: Option<(u32,u32)>, // (width, height)
+        old_swapchain: Option<vk::SwapchainKHR>,
+    ) -> Result<(vk::SwapchainKHR, vk::Format, vk::Extent2D, Vec<vk::Image>)> {
+        let support = Self::query_support(instance, physical_device, surface)?;
+        if support.formats.is_empty() || support.present_modes.is_empty() {
+            return Err(VulkanError::SwapchainCreationError("No formats or present modes available".to_string()));
+        }
+
+        let surface_format = Self::choose_surface_format(&support.formats);
+        let present_mode = Self::choose_present_mode(&support.present_modes);
+        
+        let extent = if let Some((w,h)) = preferred_dimensions {
+            Self::choose_extent(&support.capabilities, w, h)
+        } else {
+            // If no preferred dimensions, use current extent from capabilities
+            // This path is usually for recreation where we want current surface size
+            support.capabilities.current_extent 
+        };
+
+
+        let mut image_count = support.capabilities.min_image_count + 1;
+        if support.capabilities.max_image_count != 0 // 0 means no limit
+            && image_count > support.capabilities.max_image_count
+        {
+            image_count = support.capabilities.max_image_count;
+        }
+
+        let mut queue_family_indices_vec = Vec::new();
+        let image_sharing_mode = if indices.graphics_family != indices.present_family {
+            queue_family_indices_vec.push(indices.graphics_family.unwrap());
+            queue_family_indices_vec.push(indices.present_family.unwrap());
+            vk::SharingMode::CONCURRENT
+        } else {
+            vk::SharingMode::EXCLUSIVE
+        };
+
+        let mut create_info = vk::SwapchainCreateInfoKHR::builder()
+            .surface(surface)
+            .min_image_count(image_count)
+            .image_format(surface_format.format)
+            .image_color_space(surface_format.color_space)
+            .image_extent(extent)
+            .image_array_layers(1)
+            .image_usage(vk::ImageUsageFlags::COLOR_ATTACHMENT | vk::ImageUsageFlags::TRANSFER_DST) // TRANSFER_DST for clear or post-proc blit
+            .image_sharing_mode(image_sharing_mode)
+            .queue_family_indices(&queue_family_indices_vec)
+            .pre_transform(support.capabilities.current_transform)
+            .composite_alpha(vk::CompositeAlphaFlagsKHR::OPAQUE) // Assuming opaque window
+            .present_mode(present_mode)
+            .clipped(true); // Discard pixels obscured by other windows
+
+        if let Some(old) = old_swapchain {
+            create_info = create_info.old_swapchain(old);
+        }
+        
+        let swapchain = unsafe { device.create_swapchain_khr(&create_info, None) }
+            .map_err(VulkanError::VkResult)?;
+
+        let images = unsafe { device.get_swapchain_images_khr(swapchain, None) }
+            .map_err(VulkanError::VkResult)?;
+
+        Ok((swapchain, surface_format.format, extent, images))
+    }
+
+    fn create_image_views_internal(
+        device: &Device,
+        images: &[vk::Image],
+        format: vk::Format,
+    ) -> Result<Vec<vk::ImageView>> {
+        images
+            .iter()
+            .map(|&image| {
+                let components = vk::ComponentMapping::builder()
+                    .r(vk::ComponentSwizzle::IDENTITY)
+                    .g(vk::ComponentSwizzle::IDENTITY)
+                    .b(vk::ComponentSwizzle::IDENTITY)
+                    .a(vk::ComponentSwizzle::IDENTITY);
+                let subresource_range = vk::ImageSubresourceRange::builder()
+                    .aspect_mask(vk::ImageAspectFlags::COLOR)
+                    .base_mip_level(0)
+                    .level_count(1)
+                    .base_array_layer(0)
+                    .layer_count(1);
+                let create_info = vk::ImageViewCreateInfo::builder()
+                    .image(image)
+                    .view_type(vk::ImageViewType::_2D)
+                    .format(format)
+                    .components(components)
+                    .subresource_range(subresource_range);
+                unsafe { device.create_image_view(&create_info, None) }
+                    .map_err(VulkanError::VkResult)
+            })
+            .collect()
+    }
+    
+    fn cleanup_swapchain(&mut self) {
+        unsafe {
+            self.image_views.iter().for_each(|&view| {
+                self.device.destroy_image_view(view, None);
+            });
+            self.device.destroy_swapchain_khr(self.swapchain, None);
+        }
+        log::debug!("Previous swapchain and image views destroyed.");
+    }
+
+    pub fn recreate_swapchain(&mut self, new_width: u32, new_height: u32) -> Result<()> {
+        log::info!("Recreating swapchain with new dimensions: {}x{}", new_width, new_height);
+        unsafe { self.device.device_wait_idle() }.map_err(VulkanError::VkResult)?; // Ensure all GPU operations are finished.
+
+        self.cleanup_swapchain();
+
+        let (swapchain, format, extent, images) = Self::create_swapchain_internal(
+            &self.instance,
+            self.physical_device,
+            &self.device,
+            self.surface,
+            self.queue_indices,
+            Some((new_width, new_height)),
+            None, // old_swapchain is destroyed
+        )?;
+        
+        let image_views = Self::create_image_views_internal(&self.device, &images, format)?;
+
+        self.swapchain = swapchain;
+        self.format = format;
+        self.extent = extent;
+        self.images = images;
+        self.image_views = image_views;
+        
+        log::info!("Swapchain recreated successfully.");
+        Ok(())
+    }
+
+    // Getters
+    pub fn surface(&self) -> vk::SurfaceKHR { self.surface }
+    pub fn swapchain(&self) -> vk::SwapchainKHR { self.swapchain }
+    pub fn images(&self) -> &[vk::Image] { &self.images }
+    pub fn image_views(&self) -> &[vk::ImageView] { &self.image_views }
+    pub fn format(&self) -> vk::Format { self.format }
+    pub fn extent(&self) -> vk::Extent2D { self.extent }
+
+}
+
+impl Drop for SurfaceSwapchain {
+    fn drop(&mut self) {
+        self.cleanup_swapchain();
+        unsafe {
+            self.instance.destroy_surface_khr(self.surface, None);
+        }
+        log::debug!("Vulkan surface destroyed.");
+    }
+}

--- a/src/sync_primitives.rs
+++ b/src/sync_primitives.rs
@@ -1,0 +1,62 @@
+use crate::error::{Result, VulkanError};
+use crate::device::LogicalDevice;
+use std::sync::Arc;
+use vulkanalia::prelude::v1_0::*;
+
+pub struct FrameSyncPrimitives {
+    device: Arc<Device>, // For destruction
+    pub image_available_semaphore: vk::Semaphore,
+    pub render_finished_semaphore: vk::Semaphore,
+    pub in_flight_fence: vk::Fence,
+}
+
+impl FrameSyncPrimitives {
+    pub fn new(logical_device_wrapper: &LogicalDevice) -> Result<Self> {
+        let device = logical_device_wrapper.raw().clone();
+
+        let semaphore_info = vk::SemaphoreCreateInfo::builder();
+        
+        let image_available_semaphore = unsafe { device.create_semaphore(&semaphore_info, None) }
+            .map_err(VulkanError::VkResult)?;
+            
+        let render_finished_semaphore = unsafe { device.create_semaphore(&semaphore_info, None) }
+            .map_err(VulkanError::VkResult)?;
+
+        // Create fence in signaled state for the first frame
+        // vk::FenceCreateFlags::SIGNALED_BIT is the correct enum variant name in vulkanalia
+        let fence_info = vk::FenceCreateInfo::builder().flags(vk::FenceCreateFlags::SIGNALED);
+        let in_flight_fence = unsafe { device.create_fence(&fence_info, None) }
+            .map_err(VulkanError::VkResult)?;
+            
+        log::debug!("Created FrameSyncPrimitives (2 semaphores, 1 signaled fence).");
+
+        Ok(Self {
+            device,
+            image_available_semaphore,
+            render_finished_semaphore,
+            in_flight_fence,
+        })
+    }
+}
+
+impl Drop for FrameSyncPrimitives {
+    fn drop(&mut self) {
+        unsafe {
+            self.device.destroy_semaphore(self.image_available_semaphore, None);
+            self.device.destroy_semaphore(self.render_finished_semaphore, None);
+            self.device.destroy_fence(self.in_flight_fence, None);
+        }
+        log::debug!("FrameSyncPrimitives destroyed.");
+    }
+}
+
+// Helper function to create a list of sync primitives, typically called by FrameRenderer.
+// The `MAX_FRAMES_IN_FLIGHT` constant would be defined elsewhere (e.g., in FrameRenderer).
+pub fn create_sync_objects_list(
+    logical_device_wrapper: &LogicalDevice,
+    max_frames_in_flight: usize,
+) -> Result<Vec<FrameSyncPrimitives>> {
+    (0..max_frames_in_flight)
+        .map(|_| FrameSyncPrimitives::new(logical_device_wrapper))
+        .collect()
+}

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,0 +1,1 @@
+// TODO: Implement module


### PR DESCRIPTION
This commit establishes the initial framework for a Vulkan-based rendering subsystem in Rust, targeting Wayland integration with Smithay and optimization for UMA architectures.

Implemented modules include:

1.  **Error Handling (`error.rs`):** Defines `VulkanError` and `Result` types.
2.  **Instance (`instance.rs`):** Manages `VkInstance` creation, validation layers, and debug messenger.
3.  **Physical Device (`physical_device.rs`):** Selects a suitable `VkPhysicalDevice`, identifying queue families and checking extensions (including Wayland presentation and DMA-BUF).
4.  **Logical Device (`device.rs`):** Creates `VkDevice` and retrieves command queues.
5.  **Allocator (`allocator.rs`):** Integrates Vulkan Memory Allocator (VMA) for optimized buffer and image memory management.
6.  **Surface & Swapchain (`surface_swapchain.rs`):** Manages `VkSurfaceKHR` (Wayland) and `VkSwapchainKHR`, including image views and recreation logic.
7.  **Render Pass (`render_pass.rs`):** Defines a basic `VkRenderPass` with color (swapchain) and depth attachments.
8.  **Framebuffer (`framebuffer.rs`):** Provides utility to create `VkFramebuffer` objects.
9.  **Synchronization Primitives (`sync_primitives.rs`):** Manages per-frame `VkSemaphore`s and `VkFence`s for render loop synchronization.

The project structure is set up for further implementation of pipeline creation, command buffer recording, and rendering logic.