### PR TITLE
feat: Implement core Wayland compositor functionality and protocols

### DIFF
--- a/novade-system/src/compositor/core/output_handlers.rs
+++ b/novade-system/src/compositor/core/output_handlers.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 NovaDE Contributors
+// SPDX-License-Identifier: MIT
+
+use smithay::{
+    output::{Output, OutputHandler, OutputManagerState, Mode, PhysicalProperties},
+    reexports::wayland_server::protocol::wl_output::WlOutput,
+    utils::Point,
+    desktop::Space,
+};
+use crate::compositor::core::state::NovadeCompositorState;
+
+impl OutputHandler for NovadeCompositorState {
+    fn output_state(&mut self) -> &mut OutputManagerState {
+        &mut self.output_manager_state
+    }
+
+    fn new_output(&mut self, output: Output) {
+        tracing::info!("New output detected: {}", output.name());
+        
+        let mut current_max_x = 0;
+        for existing_output_element in self.space.outputs() { // Iterates over Output and its location in Space
+            // existing_output_element is &Output, not OutputWithLocation.
+            // We need its geometry in the space.
+            if let Some(geom) = self.space.output_geometry(existing_output_element) {
+                if geom.loc.x + geom.size.w > current_max_x {
+                    current_max_x = geom.loc.x + geom.size.w;
+                }
+            }
+        }
+        let position = Point::from((current_max_x, 0));
+        tracing::info!("Calculated position for new output {}: {:?}", output.name(), position);
+
+        self.space.map_output(&output, position);
+        
+        // Smithay's Output objects (version 0.10+) are typically created with their global
+        // already managed by the backend that creates them (e.g., DrmBackend, WinitBackend).
+        // If an Output is passed to new_output, its global should have been handled.
+        // We just need to store it and map it to our space.
+        
+        self.outputs.push(output);
+        // Trigger a refresh of all outputs in the space due to layout change.
+        self.space.damage_all_outputs(); 
+        tracing::info!("Output {} mapped to space at {:?} and added to state.", output.name(), position);
+    }
+
+    fn output_mode_updated(&mut self, output: &Output, new_mode: Mode) {
+        tracing::info!("Output {} mode updated to: {:?}@{}mHz", output.name(), new_mode.size, new_mode.refresh);
+        // The Output's internal state is updated by Smithay when its current_mode() is changed.
+        // The Output object itself will send the necessary wl_output.mode event to clients.
+        // We need to ensure our Space is aware of this change if it affects layout
+        // and damage the output so it's redrawn.
+        
+        // Re-mapping the output in the space implicitly updates its geometry if the mode changed size.
+        // If the position logic were more complex, we might need to recalculate it here.
+        // For now, assuming position remains (0,0) or is handled by space.map_output if it re-evaluates.
+        if let Some(current_pos) = self.space.output_geometry(output).map(|geo| geo.loc) {
+             self.space.map_output(output, current_pos); // Re-map with current position to update size if needed
+        } else {
+            // This case should ideally not happen if the output was previously mapped.
+            // If it does, map it at a default position.
+            tracing::warn!("Output {} mode updated, but it was not found in the space. Re-mapping at (0,0).", output.name());
+            self.space.map_output(output, (0,0).into());
+        }
+        
+        self.space.damage_output(output, None, None); // Damage the entire output
+        tracing::debug!("Output {} mode change processed, space updated and output damaged.", output.name());
+    }
+
+    fn output_destroyed(&mut self, destroyed_output: &Output) {
+        tracing::info!("Output destroyed: {}", destroyed_output.name());
+        self.space.unmap_output(destroyed_output);
+        self.outputs.retain(|o| o.name() != destroyed_output.name());
+        // The global for the output is automatically cleaned up by Smithay when the Output is dropped,
+        // as the Global resource is typically owned by the Output object.
+        
+        // Trigger a refresh of all outputs due to layout change.
+        self.space.damage_all_outputs();
+        tracing::info!("Output {} unmapped from space and removed from state.", destroyed_output.name());
+    }
+}

--- a/novade-system/src/compositor/core/screencopy_handlers.rs
+++ b/novade-system/src/compositor/core/screencopy_handlers.rs
@@ -1,0 +1,139 @@
+// Copyright (c) 2025 NovaDE Contributors
+// SPDX-License-Identifier: MIT
+
+use smithay::{
+    reexports::wayland_server::protocol::wl_buffer::WlBuffer,
+    wayland::screencopy::{ScreencopyHandler, ScreencopyManagerState, FrameState, BufferDamage, CaptureError},
+    wayland::shm,
+    output::Output,
+    utils::{Rectangle, BufferCoord, Transform}, // BufferCoord and Transform might be needed for damage or specific captures
+};
+use crate::compositor::core::state::NovadeCompositorState;
+// AsRawFd might not be strictly needed if shm::with_buffer_data_and_format is used, which abstracts fd handling.
+// use std::os::unix::io::AsRawFd; 
+
+impl ScreencopyHandler for NovadeCompositorState {
+    fn screencopy_state(&mut self) -> &mut ScreencopyManagerState {
+        &mut self.screencopy_state
+    }
+
+    fn capture_output_frame(
+        &mut self,
+        output: &Output,
+        damage: Option<Vec<Rectangle<i32, BufferCoord>>>,
+        frame_state: &FrameState, // Contains the WlBuffer and other frame details
+    ) -> Result<(), CaptureError> {
+        tracing::info!(
+            "Attempting dummy capture for output: {}, buffer: {:?}, damage: {:?}",
+            output.name(),
+            frame_state.buffer.id(), // Access buffer via FrameState
+            damage
+        );
+
+        let buffer = &frame_state.buffer;
+
+        // First, get buffer properties without holding the slice mutable for too long.
+        let frame_info = match shm::with_buffer_data_and_format(buffer, |_slice, data| {
+            // data contains format, width, height, stride
+            Ok(Some((data.format, data.width, data.height, data.stride)))
+        }) {
+            Ok(Some(info)) => info,
+            Ok(None) => {
+                tracing::error!("Buffer {:?} is not an SHM buffer or SHM data access failed early.", buffer.id());
+                return Err(CaptureError::UnsupportedBuffer); // Or Temporary if it might become available
+            }
+            Err(e) => {
+                tracing::error!("Failed to access buffer data for {:?} (e.g. not an SHM buffer or other error): {:?}", buffer.id(), e);
+                return Err(CaptureError::Temporary); // Indicates a transient issue
+            }
+        };
+        
+        let (buffer_format, buffer_width, buffer_height, buffer_stride) = frame_info;
+
+        let pixel_size_bytes = match buffer_format {
+            shm::Format::Argb8888 | shm::Format::Xrgb8888 => 4,
+            shm::Format::Abgr8888 | shm::Format::Xbgr8888 => 4,
+            // Add other common formats if necessary for testing, e.g., RGB formats
+            _ => {
+                tracing::error!("Unsupported buffer format for dummy capture: {:?} on buffer {:?}", buffer_format, buffer.id());
+                return Err(CaptureError::UnsupportedBuffer);
+            }
+        };
+
+        // Now, get mutable access to the slice to fill it.
+        shm::with_buffer_data_and_format(buffer, |slice, data| {
+            // It's good practice to re-check properties if concerned about TOCTOU, though less likely here.
+            if data.width != buffer_width || data.height != buffer_height || data.stride != buffer_stride {
+                tracing::error!("Buffer {:?} properties changed between reads. Aborting dummy capture.", buffer.id());
+                // This indicates a more severe issue, possibly client misbehavior or race.
+                return Err(shm::BufferAccessError::BadHandle); 
+            }
+
+            tracing::info!(
+                "Filling buffer {:?} ({}x{} stride {}) with dummy color (magenta). Format: {:?}",
+                buffer.id(), buffer_width, buffer_height, buffer_stride, buffer_format
+            );
+
+            // Fill the buffer with magenta (or another test color)
+            // The exact byte order for magenta (R=FF, G=00, B=FF, A=FF) depends on the format.
+            // For ARGB8888: 0xFFFF00FF (Bytes: BB GG RR AA -> FF 00 FF FF)
+            // For XRGB8888: 0xFFFFFF00 (Bytes: BB GG RR XX -> FF 00 FF FF, if X is most significant)
+            // For ABGR8888: 0xFFFF00FF (Bytes: RR GG BB AA -> FF 00 FF FF)
+            // For XBGR8888: 0xFFFFFF00 (Bytes: RR GG BB XX -> FF 00 FF FF)
+            // Magenta: R=255, G=0, B=255
+            
+            let (r, g, b, a) = (255u8, 0u8, 255u8, 255u8); // Magenta
+
+            for y in 0..buffer_height {
+                for x in 0..buffer_width {
+                    let offset = (y * buffer_stride + x * pixel_size_bytes) as usize;
+                    if offset + pixel_size_bytes as usize <= slice.len() {
+                        let pixel_slice = &mut slice[offset..(offset + pixel_size_bytes as usize)];
+                        match buffer_format {
+                            shm::Format::Argb8888 => { // B G R A
+                                pixel_slice[0] = b; // Blue
+                                pixel_slice[1] = g; // Green
+                                pixel_slice[2] = r; // Red
+                                pixel_slice[3] = a; // Alpha
+                            }
+                            shm::Format::Xrgb8888 => { // B G R X (X usually ignored or opaque alpha)
+                                pixel_slice[0] = b;
+                                pixel_slice[1] = g;
+                                pixel_slice[2] = r;
+                                pixel_slice[3] = 0xFF; // X (often treated as Alpha, set to opaque)
+                            }
+                             shm::Format::Abgr8888 => { // R G B A
+                                pixel_slice[0] = r; 
+                                pixel_slice[1] = g; 
+                                pixel_slice[2] = b; 
+                                pixel_slice[3] = a;
+                            }
+                            shm::Format::Xbgr8888 => { // R G B X
+                                pixel_slice[0] = r;
+                                pixel_slice[1] = g;
+                                pixel_slice[2] = b;
+                                pixel_slice[3] = 0xFF; 
+                            }
+                            _ => { /* Should have been caught by pixel_size_bytes check, but defensive */ }
+                        }
+                    }
+                }
+            }
+            Ok(())
+        }).map_err(|e| {
+            tracing::error!("Failed to write to buffer {:?} for dummy capture: {:?}", buffer.id(), e);
+            // Map shm::BufferAccessError to CaptureError appropriately
+            match e {
+                shm::BufferAccessError::BadHandle => CaptureError::UnsupportedBuffer, // Or another specific error
+                _ => CaptureError::Temporary,
+            }
+        })?;
+
+        // Smithay's ScreencopyState will call frame_state.ready() internally upon Ok(()) return.
+        Ok(())
+    }
+
+    // fn frame_destroyed(&mut self, frame: Frame) -> bool;
+    // This is now part of ScreencopyManagerState internal logic for Smithay 0.10+
+    // No need to implement it here unless custom behavior beyond default logging is needed.
+}


### PR DESCRIPTION
This commit marks a significant milestone in the Novade Wayland compositor development, including core refactoring, implementation of key Wayland protocols, and initial testing.

Completed Steps & Key Changes:

1.  **Core State Refactoring (`NovadeCompositorState`, `SurfaceData`):**
    *   I unified `SurfaceData` definition and usage between `surface_management.rs` and `core/state.rs`.
    *   I centralized `XdgShellHandler` implementation, removing redundancies.
    *   I reviewed and adjusted `NovadeCompositorState::commit` and `new_surface` for consistency.

2.  **Surface Management (`wl_surface`):**
    *   I refined `SurfaceData` for clarity and correctness.
    *   I integrated `wl_surface.frame` callback dispatch into the main event loop using `space.send_frames()`, enabling synchronized client rendering.

3.  **XDG-Shell Protocols (`xdg_shell`, `xdg_toplevel`, `xdg_popup`):**
    *   `ManagedWindow::self_update()` is now called on commit via `Window::on_commit` to sync title/app_id.
    *   I improved state restoration for unmaximize/unfullscreen using `saved_pre_action_geometry`.
    *   I added `set_parent_request` handler (logging).
    *   I ensured proper lifetime management for popup `ManagedWindow` instances using `PopupSurface::user_data()` and destruction hooks.

4.  **Decoration Protocols (`zxdg_decoration_manager_v1`):**
    *   I integrated `XdgDecorationState` into `NovadeCompositorState`.
    *   I implemented `XdgDecorationHandler` to negotiate client-side vs. server-side decorations. `ManagedWindow` state is updated accordingly. (Note: Server-side rendering of decorations is not yet implemented).

5.  **Input Handling (`wl_seat`, `wl_keyboard`, `wl_pointer`):**
    *   I implemented `SeatHandler` for `NovadeCompositorState`:
        *   Manages keyboard focus changes, activating/deactivating XDG toplevels, and raising focused windows.
        *   Handles cursor image updates.
    *   I integrated `LibinputInputBackend` into the main event loop in `main.rs` to process physical keyboard, pointer, and touch events and forward them to the `Seat`.

6.  **Output Management (`wl_output`):**
    *   I implemented `OutputHandler` for `NovadeCompositorState` to react to output lifecycle events.
    *   I replaced the placeholder output setup in `main.rs` with `WinitBackend` and `GlowRenderer`, allowing the compositor to run in a desktop window for easier development and testing. The Winit backend now drives output creation.

7.  **Multi-Monitor Support (Initial):**
    *   I implemented a basic horizontal tiling policy in `OutputHandler::new_output` to arrange multiple outputs logically within the compositor's `Space`.

8.  **Screen Capture Protocols (`zwlr_screencopy_manager_v1`):**
    *   I integrated `ScreencopyState` into `NovadeCompositorState`.
    *   I implemented `ScreencopyHandler` with a dummy frame capture (fills buffer with magenta) to examine protocol flow.

9.  **Testing and Validation (Initial):**
    *   I added unit tests for `SurfaceData` (state management).
    *   I added unit tests for `ManagedWindow`, `WindowState`, and `WindowManagerData` (initialization and basic properties), including test helpers for mock Wayland surfaces.
    *   I added unit tests for select `XdgShellHandler` methods (`set_maximized_request`, `unset_maximized_request`) using a minimal test state.

This work provides a solid foundation for further compositor development, with many essential Wayland protocols now having baseline implementations.