### PR TITLE
feat: Implement basic D-Bus client for system bus interaction

### DIFF
--- a/novade-system/Cargo.toml
+++ b/novade-system/Cargo.toml
@@ -11,3 +11,4 @@ tokio = { version = "1", features = ["full"] }
 wayland-server = "0.31.0"
 wayland-protocols = "0.31.0"
 smithay = "0.6.0"
+zbus = "3"

--- a/novade-system/examples/dbus_client_demo.rs
+++ b/novade-system/examples/dbus_client_demo.rs
@@ -1,62 +1,16 @@
-// novade-system/examples/dbus_client_demo.rs
-
-// Use the published library novade_system
-use novade_system::dbus_integration::{self, DBusIntegrationError};
-use novade_core; // Use novade_core directly as a dependency of the novade-system package.
-
-use zbus::Connection; // Import Connection for signal listening setup
+use novade_system::dbus_integration;
+use tokio;
 
 #[tokio::main]
 async fn main() {
-    println!("NovaDE System D-Bus Integration Demo");
-    println!("====================================");
-
-    // Initialize logging from novade_core
-    // This requires novade_core to be accessible.
-    match novade_core::logging::init_minimal_logging() {
-        Ok(_) => println!("Minimal logging initialized."),
-        Err(e) => eprintln!("Failed to initialize logging: {}", e),
+    println!("Starting D-Bus simple client demo...");
+    if let Err(e) = dbus_integration::connect_and_list_names().await {
+        eprintln!("Demo failed during connect_and_list_names: {}", e);
     }
-    
-    println!("\n--- Testing connect_and_list_names ---");
-    match dbus_integration::connect_and_list_names().await {
-        Ok(_) => println!("connect_and_list_names executed successfully."),
-        Err(e) => eprintln!("Error in connect_and_list_names: {}", e),
-    }
-
-    println!("\n--- Testing listen_for_name_owner_changed ---");
-    let connection_result = Connection::system().await;
-
-    match connection_result {
-        Ok(connection) => {
-            println!("Successfully connected to D-Bus for signal listening demo.");
-            let listen_handle = tokio::spawn(async move {
-                match dbus_integration::listen_for_name_owner_changed(&connection).await {
-                    Ok(_) => println!("listen_for_name_owner_changed finished (likely received a signal or completed its task)."),
-                    Err(DBusIntegrationError::SignalStreamEnded) => {
-                        println!("listen_for_name_owner_changed: Signal stream ended (no specific signal received or timeout if applicable). This is often normal.");
-                    }
-                    Err(e) => {
-                        eprintln!("Error in listen_for_name_owner_changed: {}", e);
-                    }
-                }
-            });
-
-            println!("Listening for NameOwnerChanged for a few seconds...");
-            tokio::select! {
-                _ = listen_handle => {
-                    println!("Signal listener task completed.");
-                }
-                _ = tokio::time::sleep(tokio::time::Duration::from_secs(10)) => {
-                    println!("Finished 10-second listening period for NameOwnerChanged signals.");
-                }
-            }
-        }
-        Err(e) => {
-            eprintln!("Failed to connect to D-Bus for signal listening demo: {}", e);
-            eprintln!("Skipping listen_for_name_owner_changed test.");
-        }
-    }
-    
-    println!("\n--- D-Bus Integration Demo Finished ---");
+    // Keep the demo running for a bit to allow signals to be received.
+    // In a real application, the main loop would keep things alive.
+    // For a simple demo, a short sleep can help observe signals.
+    println!("Demo running. Listening for NameOwnerChanged signals for 30 seconds...");
+    tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
+    println!("Demo finished.");
 }

--- a/novade-system/src/dbus_integration/mod.rs
+++ b/novade-system/src/dbus_integration/mod.rs
@@ -1,5 +1,62 @@
 // novade-system/src/dbus_integration/mod.rs
+use zbus::{Connection, Proxy, Error as ZbusError, SignalReceiver};
+use tokio;
+use futures_util::stream::StreamExt;
+
 pub mod examples;
 pub mod manager;
 
+// TODO: Add D-Bus client logic (connection, proxy, signal handling) here
+
+pub async fn listen_for_name_owner_changes(connection: Connection) -> Result<(), ZbusError> {
+    let proxy = Proxy::new(
+        connection.clone(),
+        "org.freedesktop.DBus",
+        "/org/freedesktop/DBus",
+        "org.freedesktop.DBus"
+    ).await?;
+    let mut signal_stream = proxy.receive_signal("NameOwnerChanged").await?;
+    println!("Listening for NameOwnerChanged signals...");
+    while let Some(signal) = signal_stream.next().await {
+        // The actual body type for NameOwnerChanged is (String, String, String)
+        // representing name, old_owner, new_owner.
+        match signal.body::<(String, String, String)>() {
+            Ok(body) => {
+                println!("Received NameOwnerChanged signal: name='{}', old_owner='{}', new_owner='{}'", body.0, body.1, body.2);
+            }
+            Err(e) => {
+                eprintln!("Error decoding NameOwnerChanged signal body: {}", e);
+            }
+        }
+    }
+    Ok(())
+}
+
+pub async fn connect_and_list_names() -> Result<Vec<String>, ZbusError> {
+    let connection = Connection::system().await?;
+
+    // Spawn the listener task
+    let conn_for_listener = connection.clone();
+    tokio::spawn(async move {
+        if let Err(e) = listen_for_name_owner_changes(conn_for_listener).await {
+            eprintln!("Error in signal listener: {}", e);
+        }
+    });
+
+    // Continue with existing logic for ListNames
+    let proxy = Proxy::new(
+        connection.clone(), // Use the original connection
+        "org.freedesktop.DBus",
+        "/org/freedesktop/DBus",
+        "org.freedesktop.DBus"
+    ).await?;
+    let names: Vec<String> = proxy.call_method("ListNames", &()).await?.body().unwrap_or_else(|_| Vec::new());
+    for name in &names {
+        println!("Found D-Bus name: {}", name); // Later replace with novade_core::logging if accessible
+    }
+    Ok(names)
+}
+
 pub use manager::{DbusServiceManager, DbusManagerError, Result as DbusManagerResult};
+
+// TODO: Define specific D-Bus interfaces and proxy interactions here


### PR DESCRIPTION
Adds initial D-Bus integration for `novade-system` using the `zbus` crate.

Key features implemented:
- Establishes a connection to the D-Bus system bus.
- Creates a proxy for the `org.freedesktop.DBus` service.
- Calls the `ListNames()` method to retrieve and print active D-Bus service names.
- Implements asynchronous listening for the `NameOwnerChanged` signal from `org.freedesktop.DBus`, printing signal details to the console.
- Includes an example (`novade-system/examples/dbus_client_demo.rs`) to demonstrate these functionalities.

The `connect_and_list_names` function in `novade_system::dbus_integration` now also spawns the `listen_for_name_owner_changes` signal listener as a concurrent tokio task.

Note: A pre-existing compilation issue related to the `atty` crate version in `novade-core` was observed during development but is unrelated to these changes.