### PR TITLE
feat: Implement NovaDE Surface Management Module

### DIFF
--- a/novade-buffer-manager/Cargo.toml
+++ b/novade-buffer-manager/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "novade-buffer-manager"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# No dependencies needed for now, but can be added later (e.g. for wayland-server)

--- a/novade-buffer-manager/src/buffer.rs
+++ b/novade-buffer-manager/src/buffer.rs
@@ -1,0 +1,378 @@
+//! Manages buffer objects and their properties.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
+
+/// Represents a unique identifier for a Wayland client.
+///
+/// This is a placeholder and might be replaced with a more robust client tracking mechanism.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ClientId(u64);
+
+impl ClientId {
+    /// Creates a new client ID.
+    ///
+    /// # Arguments
+    /// * `id`: The raw `u64` value for this client ID.
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+}
+
+/// Represents a unique identifier for a buffer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BufferId(u64);
+
+impl BufferId {
+    /// Creates a new, unique `BufferId`.
+    ///
+    /// Note: Current implementation uses a simple atomic counter. This might be
+    /// extended or replaced by a more sophisticated ID generation scheme if needed,
+    /// for example, one that reuses IDs or is specific to a Wayland display server context.
+    fn new_unique() -> Self {
+        static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
+        BufferId(NEXT_ID.fetch_add(1, Ordering::Relaxed) as u64)
+    }
+}
+
+/// Specifies the underlying type or source of a buffer's memory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BufferType {
+    /// Buffer memory is managed via a shared memory mechanism (e.g., `wl_shm`).
+    Shm,
+    /// Buffer memory is represented by a DMA buffer file descriptor.
+    DmaBuf,
+    /// Buffer memory is an opaque GPU texture, managed by the rendering backend.
+    GpuTexture,
+}
+
+/// Enumerates common pixel formats for buffers.
+///
+/// These formats typically align with Wayland's `wl_shm.format` and DRM formats.
+/// This list can be extended as more formats are supported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BufferFormat {
+    /// 32-bit ARGB format, 8 bits per channel, alpha first.
+    Argb8888,
+    /// 32-bit XRGB format, 8 bits per channel, alpha ignored (X).
+    Xrgb8888,
+    /// YUV format, NV12 (2-plane Y followed by interleaved UV).
+    Nv12,
+    // Add other formats as needed, e.g., Yuyv, Rgb565, etc.
+}
+
+/// Holds detailed information about a specific buffer.
+///
+/// This includes its dimensions, format, type, and ownership details.
+/// It also tracks the reference count for managing the buffer's lifetime.
+#[derive(Debug)]
+pub struct BufferDetails {
+    /// Unique identifier for this buffer.
+    pub id: BufferId,
+    /// The type of the buffer (e.g., SHM, DMA-BUF).
+    pub buffer_type: BufferType,
+    /// Width of the buffer in pixels.
+    pub width: u32,
+    /// Height of the buffer in pixels.
+    pub height: u32,
+    /// Stride of the buffer in bytes (bytes per row).
+    pub stride: u32,
+    /// Pixel format of the buffer.
+    pub format: BufferFormat,
+    /// Atomic reference counter for this buffer.
+    /// When this count reaches zero, the buffer can be considered for deallocation
+    /// or release back to the client.
+    pub ref_count: AtomicUsize,
+    /// Optional ID of the client that originally created or owns this buffer.
+    /// This can be used for validation purposes (e.g., ensuring a client
+    /// only attaches buffers it owns).
+    pub client_owner_id: Option<ClientId>,
+    // data: Vec<u8>, // Placeholder for actual buffer data (e.g., for SHM this might be a MappedRegion).
+    //                 // For DMA-BUF, it would be one or more file descriptors and offsets/strides per plane.
+}
+
+impl BufferDetails {
+    /// Creates a new `BufferDetails` instance.
+    ///
+    /// A unique `BufferId` is generated automatically. The initial reference count is set to 1,
+    /// representing the "owner" or the entity that registered it (typically the `BufferManager` itself,
+    /// or the client that created it via a Wayland request).
+    ///
+    /// # Arguments
+    /// * `buffer_type`: The type of the buffer.
+    /// * `width`: Width of the buffer in pixels. Must be positive.
+    /// * `height`: Height of the buffer in pixels. Must be positive.
+    /// * `stride`: Stride of the buffer in bytes. Must be sufficient for `width` and format.
+    /// * `format`: Pixel format of the buffer.
+    /// * `client_owner_id`: Optional `ClientId` of the buffer's owner.
+    pub fn new(
+        buffer_type: BufferType,
+        width: u32,
+        height: u32,
+        stride: u32,
+        format: BufferFormat,
+        client_owner_id: Option<ClientId>,
+    ) -> Self {
+        // Basic validation for dimensions, though more strict checks might apply
+        // depending on buffer type or usage context (e.g., in BufferManager::register_buffer).
+        debug_assert!(width > 0, "Buffer width must be positive.");
+        debug_assert!(height > 0, "Buffer height must be positive.");
+
+        Self {
+            id: BufferId::new_unique(),
+            buffer_type,
+            width,
+            height,
+            stride,
+            format,
+            ref_count: AtomicUsize::new(1), // Starts with a ref count of 1 (the owner)
+            client_owner_id,
+        }
+    }
+
+    /// Increments the atomic reference count of the buffer.
+    pub fn increment_ref_count(&self) {
+        self.ref_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Decrements the atomic reference count of the buffer.
+    ///
+    /// # Returns
+    /// `true` if the reference count reached zero after decrementing, `false` otherwise.
+    pub fn decrement_ref_count(&self) -> bool {
+        self.ref_count.fetch_sub(1, Ordering::Relaxed) == 1
+    }
+}
+
+/// Manages a collection of `BufferDetails` shared across the compositor.
+///
+/// It allows registering new buffers, retrieving their details, and managing their
+/// lifecycle through reference counting.
+#[derive(Default)]
+pub struct BufferManager {
+    buffers: HashMap<BufferId, Arc<Mutex<BufferDetails>>>,
+}
+
+impl BufferManager {
+    /// Creates a new, empty `BufferManager`.
+    pub fn new() -> Self {
+        Self {
+            buffers: HashMap::new(),
+        }
+    }
+
+    /// Registers a new buffer with the specified properties.
+    ///
+    /// This function typically corresponds to a client request to create a buffer
+    /// (e.g., `wl_shm_pool.create_buffer` or importing a DMA-BUF).
+    /// The `BufferManager` takes ownership of tracking this buffer.
+    ///
+    /// # Arguments
+    /// * `buffer_type`: The type of the buffer.
+    /// * `width`: Width in pixels.
+    /// * `height`: Height in pixels.
+    /// * `stride`: Stride in bytes.
+    /// * `format`: Pixel format.
+    /// * `client_owner_id`: Optional `ClientId` of the owner.
+    ///
+    /// # Returns
+    /// An `Arc<Mutex<BufferDetails>>` for the newly registered buffer. The buffer
+    /// will have an initial reference count of 1.
+    ///
+    /// # Notes
+    /// - If this function were handling raw Wayland requests (e.g., from `wl_shm`),
+    ///   it would perform more extensive validation (FD validity, offset/stride against pool size,
+    ///   format support) and memory mapping. Errors like `InvalidFormat`, `InvalidStride`,
+    ///   `InvalidFd`, or memory mapping failures (leading to `wl_display.error(no_memory)`)
+    ///   would originate from such a process.
+    /// - Robust `no_memory` handling for `BufferDetails` allocation itself (and the `Arc<Mutex<>>`)
+    ///   would involve fallible allocation and error propagation. Currently, Rust's default
+    ///   allocators will panic on OOM.
+    pub fn register_buffer(
+        &mut self,
+        buffer_type: BufferType,
+        width: u32,
+        height: u32,
+        stride: u32,
+        format: BufferFormat,
+        client_owner_id: Option<ClientId>,
+    ) -> Arc<Mutex<BufferDetails>> {
+        // Note on Wayland SHM buffer creation: (This comment was actually good and relevant here)
+        // If this function were creating a buffer from a file descriptor (e.g., for wl_shm_pool_create_buffer),
+        // it would perform validations like:
+        // - Checking if the FD is valid.
+        // - Checking if offset and stride are valid for the given FD size and buffer dimensions.
+        //   (e.g., offset + stride * height <= pool_size).
+        // - Validating format against supported wl_shm.format enums.
+        // Errors like InvalidFormat, InvalidStride, InvalidFd would originate here.
+        // It would also handle memory mapping (mmap) which could fail (e.g., no_memory).
+        // If mmap fails, a wl_display.error(no_memory) should be sent.
+        let details = BufferDetails::new(
+            buffer_type,
+            width,
+            height,
+            stride,
+            format,
+            client_owner_id,
+        );
+        let id = details.id;
+        let arc_details = Arc::new(Mutex::new(details));
+        self.buffers.insert(id, arc_details.clone());
+        arc_details
+    }
+
+    /// Retrieves the shared `BufferDetails` for a given `BufferId`.
+    ///
+    /// # Arguments
+    /// * `id`: The `BufferId` of the buffer to retrieve.
+    ///
+    /// # Returns
+    /// An `Option<Arc<Mutex<BufferDetails>>>`. Returns `Some` if the buffer is found,
+    /// `None` otherwise.
+    pub fn get_buffer_details(&self, id: BufferId) -> Option<Arc<Mutex<BufferDetails>>> {
+        self.buffers.get(&id).cloned()
+    }
+
+    /// Releases a reference to a buffer.
+    ///
+    /// This should be called when a component (e.g., a surface) no longer needs to use
+    /// the buffer. It decrements the buffer's reference count. If the reference count
+    /// drops to zero, the buffer is removed from the manager and can be considered
+    /// fully released (e.g., the client can be notified via `wl_buffer.release`).
+    ///
+    /// # Arguments
+    /// * `id`: The `BufferId` of the buffer to release.
+    ///
+    /// # Returns
+    /// An `Option<Arc<Mutex<BufferDetails>>>`.
+    /// - If the buffer was found and its reference count was decremented but is still greater than zero,
+    ///   it returns `Some(Arc<Mutex<BufferDetails>>)` (cloned).
+    /// - If the buffer was found and its reference count reached zero (and thus it was removed from the manager),
+    ///   it returns `Some(Arc<Mutex<BufferDetails>>)` containing the buffer details just before removal.
+    /// - If the buffer was not found in the manager, it returns `None`.
+    pub fn release_buffer(&mut self, id: BufferId) -> Option<Arc<Mutex<BufferDetails>>> {
+        let buffer_arc = self.buffers.get(&id)?;
+        let should_remove = {
+            let buffer_details = buffer_arc.lock().unwrap(); // Handle potential poison
+            buffer_details.decrement_ref_count()
+        };
+
+        if should_remove {
+            // If ref_count is zero, remove from manager.
+            // Actual wl_buffer.release would be triggered here or by the caller.
+            self.buffers.remove(&id)
+        } else {
+            // Still referenced elsewhere
+            Some(buffer_arc.clone())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread; // For testing unique IDs across threads, though basic test won't need this complexity yet.
+
+    #[test]
+    fn test_unique_buffer_ids() {
+        let id1 = BufferId::new_unique();
+        let id2 = BufferId::new_unique();
+        assert_ne!(id1, id2, "BufferId::new_unique should generate unique IDs.");
+    }
+
+    #[test]
+    fn test_register_buffer() {
+        let mut manager = BufferManager::new();
+        let client_id = Some(ClientId::new(1));
+        let buffer_arc = manager.register_buffer(
+            BufferType::Shm,
+            640,
+            480,
+            640 * 4,
+            BufferFormat::Argb8888,
+            client_id,
+        );
+
+        let id = buffer_arc.lock().unwrap().id;
+        assert!(manager.buffers.contains_key(&id), "Buffer should be registered.");
+
+        let details = manager.get_buffer_details(id).unwrap();
+        let locked_details = details.lock().unwrap();
+        assert_eq!(locked_details.width, 640);
+        assert_eq!(locked_details.height, 480);
+        assert_eq!(locked_details.stride, 640 * 4);
+        assert_eq!(locked_details.format, BufferFormat::Argb8888);
+        assert_eq!(locked_details.client_owner_id, client_id);
+        assert_eq!(locked_details.ref_count.load(Ordering::SeqCst), 1, "Initial ref count should be 1.");
+    }
+
+    #[test]
+    fn test_get_buffer_details() {
+        let mut manager = BufferManager::new();
+        let client_id = Some(ClientId::new(1));
+        let buffer_arc = manager.register_buffer(
+            BufferType::Shm, 100, 200, 400, BufferFormat::Xrgb8888, client_id
+        );
+        let id = buffer_arc.lock().unwrap().id;
+
+        // Test getting existing buffer
+        let retrieved_arc = manager.get_buffer_details(id);
+        assert!(retrieved_arc.is_some(), "Should retrieve registered buffer.");
+        let details = retrieved_arc.unwrap().lock().unwrap();
+        assert_eq!(details.id, id);
+        assert_eq!(details.width, 100);
+
+        // Test getting non-existent buffer
+        let non_existent_id = BufferId::new_unique(); // Ensure it's different
+        let non_existent_retrieved = manager.get_buffer_details(non_existent_id);
+        assert!(non_existent_retrieved.is_none(), "Should not retrieve non-existent buffer.");
+    }
+
+    #[test]
+    fn test_buffer_reference_counting() {
+        let mut manager = BufferManager::new();
+        let client_id = Some(ClientId::new(1));
+        let buffer_arc = manager.register_buffer(
+            BufferType::Shm, 32, 32, 128, BufferFormat::Argb8888, client_id
+        );
+        let id = buffer_arc.lock().unwrap().id;
+
+        // Initial ref count is 1 (from registration by manager)
+        assert_eq!(buffer_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 1);
+
+        // Simulate external references
+        buffer_arc.lock().unwrap().increment_ref_count(); // Ref count becomes 2
+        assert_eq!(buffer_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 2);
+
+        buffer_arc.lock().unwrap().increment_ref_count(); // Ref count becomes 3
+        assert_eq!(buffer_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 3);
+
+        // First release (e.g., one user drops its reference)
+        // This is simulated by BufferDetails::decrement_ref_count directly for simplicity,
+        // as BufferManager::release_buffer also checks if it should remove.
+        let was_last_ref1 = buffer_arc.lock().unwrap().decrement_ref_count(); // Count becomes 2
+        assert!(!was_last_ref1, "Should not be the last reference yet.");
+        assert_eq!(buffer_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 2);
+        assert!(manager.get_buffer_details(id).is_some(), "Buffer should still be in manager.");
+
+        // Second release by BufferManager (simulates a surface releasing it)
+        // BufferManager::release_buffer will call decrement_ref_count.
+        let released_arc1 = manager.release_buffer(id); // Count becomes 1
+        assert!(released_arc1.is_some(), "release_buffer should return the Arc if not last ref.");
+        assert_eq!(buffer_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 1);
+        assert!(manager.get_buffer_details(id).is_some(), "Buffer should still be in manager after one release by manager.");
+
+        // Third release by BufferManager (simulates the original owner/manager releasing it)
+        // This should be the final release.
+        let released_arc2 = manager.release_buffer(id); // Count becomes 0
+        assert!(released_arc2.is_some(), "release_buffer should return the Arc on final release before removal.");
+         // The ref_count on `buffer_arc` itself is now 0, but the Arc still exists via `released_arc2`.
+         // The manager should have removed its own tracking Arc.
+        assert_eq!(buffer_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 0, "Ref count should be 0 before manager removes it.");
+        assert!(manager.get_buffer_details(id).is_none(), "Buffer should be removed from manager after final release.");
+
+        // Further releases should do nothing or error (current impl returns None)
+        assert!(manager.release_buffer(id).is_none(), "Releasing already removed buffer should return None.");
+    }
+}

--- a/novade-buffer-manager/src/lib.rs
+++ b/novade-buffer-manager/src/lib.rs
@@ -1,0 +1,13 @@
+//! # Novade Buffer Manager
+//!
+//! This crate provides core functionalities for managing buffer objects within the
+//! Novade compositor. It handles buffer registration, reference counting, and provides
+//! structures for describing buffer properties like type, format, and dimensions.
+//!
+//! It is designed to be used by other components of the compositor, such as the
+//! surface management system, to associate buffers with surfaces for rendering.
+
+pub mod buffer;
+
+// Re-export key types for convenience.
+pub use buffer::{BufferManager, BufferDetails, BufferId, BufferType, BufferFormat, ClientId};

--- a/novade-compositor-core/Cargo.toml
+++ b/novade-compositor-core/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "novade-compositor-core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+novade-buffer-manager = { path = "../novade-buffer-manager" }
+
+# Add other dependencies as needed, e.g. wayland-server
+# For example:
+# wayland-server = "0.30"
+# slog = "2.7"
+# slog-term = "2.9"
+# slog-async = "2.7"

--- a/novade-compositor-core/src/lib.rs
+++ b/novade-compositor-core/src/lib.rs
@@ -1,0 +1,15 @@
+//! # Novade Compositor Core
+//!
+//! This crate forms the core logic for the Novade Wayland compositor.
+//! It includes management of:
+//! - Surfaces (`wl_surface`): Their state, attributes, pending vs. current state,
+//!   damage tracking, and commit lifecycle.
+//! - Subsurfaces (`wl_subsurface`): Hierarchy, synchronization, and stacking order.
+//! - Buffers: (Via `novade-buffer-manager`) Association with surfaces.
+//!
+//! The core is responsible for maintaining the scene graph and the state of
+//! various Wayland objects that clients interact with. It provides the foundational
+//! building blocks upon which protocol handling and rendering are built.
+
+pub mod surface;
+pub mod subcompositor;

--- a/novade-compositor-core/src/subcompositor.rs
+++ b/novade-compositor-core/src/subcompositor.rs
@@ -1,0 +1,699 @@
+//! # Subcompositor Logic
+//!
+//! This module implements the core logic for `wl_subcompositor` and `wl_subsurface`
+//! Wayland interfaces. It handles the creation, destruction, and manipulation of
+//! subsurfaces, including their relationship to parent surfaces, stacking order (Z-order),
+//! and synchronization modes.
+//!
+//! The actual Wayland protocol binding would call into these functions.
+
+use crate::surface::{SurfaceId, Surface, SurfaceRole};
+use crate::surface::surface_registry::SurfaceRegistry;
+use std::sync::{Arc, Mutex};
+
+/// Defines the synchronization behavior of a subsurface relative to its parent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubsurfaceSyncMode {
+    /// The subsurface's state is cached upon its own commit and applied only when
+    /// its parent surface's state is applied (committed). This is the default mode.
+    Synchronized,
+    /// The subsurface's state is applied independently of its parent's commit cycle.
+    /// Changes to the subsurface become visible once its own `wl_surface.commit` is processed.
+    Desynchronized,
+}
+
+impl Default for SubsurfaceSyncMode {
+    fn default() -> Self {
+        SubsurfaceSyncMode::Synchronized
+    }
+}
+
+/// Holds the state specific to a surface when it acts as a subsurface.
+#[derive(Debug, Clone)]
+pub struct SubsurfaceState {
+    /// The `SurfaceId` of the parent surface.
+    pub parent_id: SurfaceId,
+    /// The desired position of the subsurface relative to its parent's origin.
+    /// This is set by `wl_subsurface.set_position` and applied on parent commit.
+    pub desired_position: (i32, i32),
+    /// The current applied position of the subsurface relative to its parent.
+    pub current_position: (i32, i32),
+    /// The synchronization mode of the subsurface.
+    pub sync_mode: SubsurfaceSyncMode,
+    /// Flag used in synchronized mode. If true, the subsurface has pending cached state
+    /// that needs to be applied when its parent commits.
+    pub needs_apply_on_parent_commit: bool,
+}
+
+impl SubsurfaceState {
+    /// Creates a new `SubsurfaceState` associated with a parent surface.
+    ///
+    /// # Arguments
+    /// * `parent_id`: The `SurfaceId` of the surface that will be the parent.
+    pub fn new(parent_id: SurfaceId) -> Self {
+        Self {
+            parent_id,
+            desired_position: (0, 0),
+            current_position: (0, 0),
+            sync_mode: SubsurfaceSyncMode::default(),
+            needs_apply_on_parent_commit: false,
+        }
+    }
+}
+
+/// Errors that can occur during subsurface operations.
+#[derive(Debug)]
+pub enum SubsurfaceError {
+    /// The provided surface ID is invalid, not found, or cannot be used in this context.
+    BadSurface,
+    /// The provided parent surface ID is invalid, not found, or cannot be used as a parent.
+    BadParent,
+    /// The surface already has an assigned role (e.g., toplevel, another subsurface object).
+    SurfaceHasRole,
+    /// The operation is intended for a surface with a subsurface role, but it doesn't have one.
+    NotASubsurface,
+    /// (Currently unused by functions returning it, but defined for completeness)
+    /// Sibling operations require the target to be a child of the same parent,
+    /// or other parent-related validation failed.
+    NotAParent,
+    /// An attempt was made to create a parent-child relationship that would form a cycle.
+    CycleDetected,
+    /// The specified sibling surface for a stacking operation was not found as a child of the same parent.
+    SiblingNotFound,
+}
+
+
+/// Handles the `wl_subcompositor.get_subsurface` request logic.
+///
+/// This function establishes a parent-child relationship between two surfaces,
+/// turning the child `surface_id` into a subsurface of `parent_id`.
+///
+/// # Arguments
+/// * `_subcompositor_resource_id`: The Wayland resource ID of the `wl_subcompositor` global.
+///   (Typically unused in the core logic, but present for API completeness).
+/// * `_new_subsurface_resource_id`: The Wayland resource ID for the new `wl_subsurface` object.
+///   (Typically unused in the core logic, as the association is `wl_subsurface` -> `child_surface_id`).
+/// * `surface_id`: The `SurfaceId` of the `wl_surface` to become a subsurface.
+/// * `parent_id`: The `SurfaceId` of the `wl_surface` to become the parent.
+/// * `registry`: A reference to the `SurfaceRegistry` to access and modify surface states.
+///
+/// # Returns
+/// `Ok(())` if the subsurface is successfully created and associated.
+/// `Err(SubsurfaceError)` if any validation fails (e.g., cycle detected, surface already has a role).
+pub fn get_subsurface(
+    _subcompositor_resource_id: u32,
+    _new_subsurface_resource_id: u32,
+    surface_id: SurfaceId,
+    parent_id: SurfaceId,
+    registry: &SurfaceRegistry,
+) -> Result<(), SubsurfaceError> {
+
+    if surface_id == parent_id {
+        return Err(SubsurfaceError::CycleDetected);
+    }
+
+    // Cycle detection: Check if surface_id is an ancestor of parent_id.
+    let mut current_ancestor_id_opt = Some(parent_id);
+    while let Some(current_ancestor_id) = current_ancestor_id_opt {
+        if current_ancestor_id == surface_id {
+            return Err(SubsurfaceError::CycleDetected);
+        }
+        let ancestor_surface_arc = registry.get_surface(current_ancestor_id);
+        if let Some(arc) = ancestor_surface_arc {
+            // It's important to handle potential panics if a lock is poisoned.
+            // For simplicity in this example, using unwrap().
+            let ancestor_surface = arc.lock().unwrap();
+            current_ancestor_id_opt = ancestor_surface.parent;
+        } else {
+            // This implies parent_id (or an ancestor) does not exist in the registry,
+            // which is a BadParent error condition.
+            return Err(SubsurfaceError::BadParent);
+        }
+    }
+
+    let surface_arc = registry.get_surface(surface_id).ok_or(SubsurfaceError::BadSurface)?;
+    let parent_arc = registry.get_surface(parent_id).ok_or(SubsurfaceError::BadParent)?; // Already checked if parent_id itself is valid
+
+    // Lock order: parent then child to avoid potential AB-BA deadlocks if simultaneous
+    // operations occur on the same pair.
+    let mut parent_surface = parent_arc.lock().unwrap();
+    let mut surface = surface_arc.lock().unwrap();
+
+    if surface.role.is_some() {
+        return Err(SubsurfaceError::SurfaceHasRole);
+    }
+
+    surface.role = Some(SurfaceRole::Subsurface(SubsurfaceState::new(parent_id)));
+    surface.parent = Some(parent_id);
+    parent_surface.children.push(surface_id); // New subsurfaces are initially top-most among siblings.
+    Ok(())
+}
+
+/// Handles the `wl_subsurface.destroy` request logic.
+///
+/// This function removes the subsurface role from the given surface. The `wl_surface`
+/// itself is not destroyed by this call but is disassociated from its parent and
+/// effectively unmapped. The client is responsible for destroying the `wl_surface` resource separately.
+///
+/// # Arguments
+/// * `subsurface_surface_id`: The `SurfaceId` of the `wl_surface` whose subsurface role is to be destroyed.
+/// * `registry`: A mutable reference to the `SurfaceRegistry` to modify surface states.
+///   (Mutable because it might modify the parent's children list).
+///
+/// # Returns
+/// `Ok(())` if the role was successfully removed or if the surface was not a subsurface (no-op).
+/// `Err(SubsurfaceError::BadSurface)` if the `subsurface_surface_id` is not found in the registry.
+pub fn destroy_subsurface_role(
+    subsurface_surface_id: SurfaceId,
+    registry: &mut SurfaceRegistry,
+) -> Result<(), SubsurfaceError> {
+    let surface_arc = registry.get_surface(subsurface_surface_id).ok_or(SubsurfaceError::BadSurface)?;
+
+    let old_parent_id = { // Scope for surface lock
+        let mut surface = surface_arc.lock().unwrap();
+        if let Some(SurfaceRole::Subsurface(sub_state)) = &surface.role {
+            let parent_id = sub_state.parent_id;
+            surface.role = None;
+            surface.parent = None;
+            Some(parent_id)
+        } else {
+            // Not a subsurface, or role already cleared. This is a no-op as per Wayland spec.
+            return Ok(());
+        }
+    };
+
+    if let Some(parent_id) = old_parent_id {
+        if let Some(parent_arc) = registry.get_surface(parent_id) {
+            let mut parent_surface = parent_arc.lock().unwrap();
+            parent_surface.children.retain(|&child_id| child_id != subsurface_surface_id);
+        }
+        // If parent_surface is not found, it might have been destroyed. The child is already unlinked.
+    }
+    Ok(())
+}
+
+/// Handles the `wl_subsurface.set_position` request logic.
+///
+/// Sets the desired position of the subsurface relative to its parent's origin.
+/// This position is cached in `SubsurfaceState::desired_position` and is typically
+/// applied to `SubsurfaceState::current_position` when the parent surface's state is committed.
+///
+/// # Arguments
+/// * `subsurface_surface_id`: The `SurfaceId` of the subsurface.
+/// * `x`: The x-coordinate of the desired position.
+/// * `y`: The y-coordinate of the desired position.
+/// * `registry`: A reference to the `SurfaceRegistry` to access the surface.
+///
+/// # Returns
+/// `Ok(())` on success.
+/// `Err(SubsurfaceError::BadSurface)` if the surface is not found.
+/// `Err(SubsurfaceError::NotASubsurface)` if the surface does not have a subsurface role.
+pub fn set_position(
+    subsurface_surface_id: SurfaceId,
+    x: i32,
+    y: i32,
+    registry: &SurfaceRegistry,
+) -> Result<(), SubsurfaceError> {
+    let surface_arc = registry.get_surface(subsurface_surface_id).ok_or(SubsurfaceError::BadSurface)?;
+    let mut surface = surface_arc.lock().unwrap();
+
+    if let Some(SurfaceRole::Subsurface(ref mut state)) = surface.role {
+        state.desired_position = (x,y);
+        Ok(())
+    } else {
+        Err(SubsurfaceError::NotASubsurface)
+    }
+}
+
+/// Helper function to reorder a surface within its parent's children list.
+/// This function assumes `surface_to_move_id` is already a child of `parent_surface`
+/// and `reference_sibling_id` is also a child (unless it's a special case handled by caller).
+fn reorder_children(
+    parent_surface: &mut Surface,
+    surface_to_move_id: SurfaceId,
+    reference_sibling_id: SurfaceId,
+    place_above: bool,
+) -> Result<(), SubsurfaceError> {
+    if !parent_surface.children.contains(&surface_to_move_id) {
+        return Err(SubsurfaceError::BadSurface);
+    }
+    if surface_to_move_id == reference_sibling_id {
+        return Ok(());
+    }
+
+    // Remove the surface to move from its current position.
+    parent_surface.children.retain(|&id| id != surface_to_move_id);
+
+    // Find the position of the reference sibling.
+    if let Some(pos) = parent_surface.children.iter().position(|&id| id == reference_sibling_id) {
+        if place_above { // Place surface_to_move_id immediately after reference_sibling_id
+            parent_surface.children.insert(pos + 1, surface_to_move_id);
+        } else { // Place surface_to_move_id immediately before reference_sibling_id
+            parent_surface.children.insert(pos, surface_to_move_id);
+        }
+    } else {
+        // This case should ideally be handled by the calling functions (place_above/place_below)
+        // if the sibling is not found, as they implement the spec's fallback (top/bottom of stack).
+        // If this helper is called with an invalid sibling_id that wasn't pre-validated, it's an error.
+        return Err(SubsurfaceError::SiblingNotFound);
+    }
+    Ok(())
+}
+
+
+/// Handles the `wl_subsurface.place_above` request logic.
+///
+/// Places the subsurface `subsurface_surface_id` immediately above `sibling_surface_id`
+/// in the stacking order of the parent. If `sibling_surface_id` is not a valid sibling
+/// (not a child of the same parent, or is the subsurface itself), the subsurface is placed
+/// at the top of the stack among its siblings.
+///
+/// # Arguments
+/// * `subsurface_surface_id`: The subsurface to reorder.
+/// * `sibling_surface_id`: The reference sibling surface.
+/// * `registry`: Access to the surface registry.
+///
+/// # Returns
+/// `Ok(())` on success, or an error if the surfaces are invalid or not related correctly.
+pub fn place_above(
+    subsurface_surface_id: SurfaceId,
+    sibling_surface_id: SurfaceId,
+    registry: &SurfaceRegistry,
+) -> Result<(), SubsurfaceError> {
+    let surface_arc = registry.get_surface(subsurface_surface_id).ok_or(SubsurfaceError::BadSurface)?;
+    let parent_id = {
+        let surface_guard = surface_arc.lock().unwrap();
+        match &surface_guard.role {
+            Some(SurfaceRole::Subsurface(state)) => state.parent_id,
+            _ => return Err(SubsurfaceError::NotASubsurface),
+        }
+    };
+
+    let parent_arc = registry.get_surface(parent_id).ok_or(SubsurfaceError::BadParent)?;
+    let mut parent_surface = parent_arc.lock().unwrap();
+
+    if subsurface_surface_id == sibling_surface_id { return Ok(()); } // No change relative to self
+
+    // If sibling is not a child of the same parent, place at the top.
+    if !parent_surface.children.contains(&sibling_surface_id) {
+        parent_surface.children.retain(|&id| id != subsurface_surface_id);
+        parent_surface.children.push(subsurface_surface_id);
+        return Ok(());
+    }
+
+    reorder_children(&mut parent_surface, subsurface_surface_id, sibling_surface_id, true)
+}
+
+/// Handles the `wl_subsurface.place_below` request logic.
+///
+/// Places the subsurface `subsurface_surface_id` immediately below `sibling_surface_id`
+/// in the stacking order of the parent. If `sibling_surface_id` is not a valid sibling
+/// (not a child of the same parent, or is the subsurface itself), the subsurface is placed
+/// at the bottom of the stack among its siblings.
+///
+/// # Arguments
+/// * `subsurface_surface_id`: The subsurface to reorder.
+/// * `sibling_surface_id`: The reference sibling surface.
+/// * `registry`: Access to the surface registry.
+///
+/// # Returns
+/// `Ok(())` on success, or an error if the surfaces are invalid or not related correctly.
+pub fn place_below(
+    subsurface_surface_id: SurfaceId,
+    sibling_surface_id: SurfaceId,
+    registry: &SurfaceRegistry,
+) -> Result<(), SubsurfaceError> {
+    let surface_arc = registry.get_surface(subsurface_surface_id).ok_or(SubsurfaceError::BadSurface)?;
+    let parent_id = {
+        let surface_guard = surface_arc.lock().unwrap();
+        match &surface_guard.role {
+            Some(SurfaceRole::Subsurface(state)) => state.parent_id,
+            _ => return Err(SubsurfaceError::NotASubsurface),
+        }
+    };
+
+    let parent_arc = registry.get_surface(parent_id).ok_or(SubsurfaceError::BadParent)?;
+    let mut parent_surface = parent_arc.lock().unwrap();
+
+    if subsurface_surface_id == sibling_surface_id { return Ok(()); } // No change relative to self
+
+    // If sibling is not a child of the same parent, place at the bottom.
+    if !parent_surface.children.contains(&sibling_surface_id) {
+        parent_surface.children.retain(|&id| id != subsurface_surface_id);
+        parent_surface.children.insert(0, subsurface_surface_id);
+        return Ok(());
+    }
+
+    reorder_children(&mut parent_surface, subsurface_surface_id, sibling_surface_id, false)
+}
+
+/// Handles `wl_subsurface.set_sync` and `wl_subsurface.set_desync` requests logic.
+///
+/// Updates the synchronization mode of the subsurface.
+///
+/// # Arguments
+/// * `subsurface_surface_id`: The `SurfaceId` of the subsurface.
+/// * `sync_mode`: The new `SubsurfaceSyncMode` to apply.
+/// * `registry`: A reference to the `SurfaceRegistry`.
+///
+/// # Returns
+/// `Ok(())` on success.
+/// `Err(SubsurfaceError::BadSurface)` if the surface is not found.
+/// `Err(SubsurfaceError::NotASubsurface)` if the surface does not have a subsurface role.
+pub fn set_sync_mode(
+    subsurface_surface_id: SurfaceId,
+    sync_mode: SubsurfaceSyncMode,
+    registry: &SurfaceRegistry,
+) -> Result<(), SubsurfaceError> {
+    let surface_arc = registry.get_surface(subsurface_surface_id).ok_or(SubsurfaceError::BadSurface)?;
+    let mut surface = surface_arc.lock().unwrap();
+
+    if let Some(SurfaceRole::Subsurface(ref mut state)) = surface.role {
+        state.sync_mode = sync_mode;
+        // Note: If transitioning from Synchronized to Desynchronized, the Wayland spec implies
+        // that any cached state should be applied immediately. This logic is currently handled
+        // within `Surface::commit()` when a desynchronized subsurface (that was previously sync) commits.
+        Ok(())
+    } else {
+        Err(SubsurfaceError::NotASubsurface)
+    }
+}
+
+// Note: wl_subcompositor.destroy is typically handled by the client destroying the global object.
+// No specific function is usually needed in the core logic for the subcompositor itself,
+// unless the compositor needs to track multiple subcompositor instances or perform specific
+// cleanup when a subcompositor global is unbound.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::surface::{Surface, SurfaceId, SurfaceState};
+    use crate::surface::surface_registry::SurfaceRegistry;
+    use crate::buffer_manager::BufferManager; // For unregister/destroy tests
+
+    // Helper to create a registry and add a surface, returning its ID and Arc.
+    fn create_surface_in_registry(registry: &mut SurfaceRegistry) -> (SurfaceId, Arc<Mutex<Surface>>) {
+        registry.register_new_surface()
+    }
+
+    // Helper to get role for assertion convenience
+    fn get_surface_role(surface_arc: &Arc<Mutex<Surface>>) -> Option<SurfaceRole> {
+        surface_arc.lock().unwrap().role.clone()
+    }
+
+    #[test]
+    fn test_get_subsurface_success() {
+        let mut registry = SurfaceRegistry::new();
+        let (parent_id, parent_arc) = create_surface_in_registry(&mut registry);
+        let (child_id, child_arc) = create_surface_in_registry(&mut registry);
+
+        let result = get_subsurface(0, 0, child_id, parent_id, &registry);
+        assert!(result.is_ok());
+
+        let child_surface = child_arc.lock().unwrap();
+        assert_eq!(child_surface.parent, Some(parent_id));
+        match &child_surface.role {
+            Some(SurfaceRole::Subsurface(sub_state)) => {
+                assert_eq!(sub_state.parent_id, parent_id);
+                assert_eq!(sub_state.sync_mode, SubsurfaceSyncMode::Synchronized); // Default
+                assert_eq!(sub_state.desired_position, (0,0)); // Default
+            }
+            _ => panic!("Child surface does not have Subsurface role."),
+        }
+
+        let parent_surface = parent_arc.lock().unwrap();
+        assert!(parent_surface.children.contains(&child_id));
+    }
+
+    #[test]
+    fn test_get_subsurface_fail_already_role() {
+        let mut registry = SurfaceRegistry::new();
+        let (parent_id, _) = create_surface_in_registry(&mut registry);
+        let (child_id, child_arc) = create_surface_in_registry(&mut registry);
+
+        // Give child a role first
+        child_arc.lock().unwrap().role = Some(SurfaceRole::Toplevel);
+
+        let result = get_subsurface(0, 0, child_id, parent_id, &registry);
+        assert!(matches!(result, Err(SubsurfaceError::SurfaceHasRole)));
+    }
+
+    #[test]
+    fn test_get_subsurface_fail_cycle_direct() {
+        let mut registry = SurfaceRegistry::new();
+        let (s1_id, _) = create_surface_in_registry(&mut registry);
+
+        let result = get_subsurface(0, 0, s1_id, s1_id, &registry);
+        assert!(matches!(result, Err(SubsurfaceError::CycleDetected)));
+    }
+
+    #[test]
+    fn test_get_subsurface_fail_cycle_indirect() {
+        let mut registry = SurfaceRegistry::new();
+        let (s1_id, s1_arc) = create_surface_in_registry(&mut registry);
+        let (s2_id, s2_arc) = create_surface_in_registry(&mut registry);
+        let (s3_id, _) = create_surface_in_registry(&mut registry);
+
+        // s1 -> s2 (s2 is child of s1)
+        get_subsurface(0,0, s2_id, s1_id, &registry).unwrap();
+
+        // s2 -> s3 (s3 is child of s2)
+        get_subsurface(0,0, s3_id, s2_id, &registry).unwrap();
+
+        // Attempt s3 -> s1 (should fail, creates s1 -> s2 -> s3 -> s1 cycle)
+        let result = get_subsurface(0, 0, s1_id, s3_id, &registry);
+        assert!(matches!(result, Err(SubsurfaceError::CycleDetected)));
+    }
+
+    #[test]
+    fn test_destroy_subsurface_role() {
+        let mut registry = SurfaceRegistry::new();
+        let (parent_id, parent_arc) = create_surface_in_registry(&mut registry);
+        let (child_id, child_arc) = create_surface_in_registry(&mut registry);
+
+        get_subsurface(0, 0, child_id, parent_id, &registry).unwrap();
+        assert!(child_arc.lock().unwrap().role.is_some());
+        assert!(parent_arc.lock().unwrap().children.contains(&child_id));
+
+        let result = destroy_subsurface_role(child_id, &mut registry);
+        assert!(result.is_ok());
+
+        assert!(child_arc.lock().unwrap().role.is_none(), "Child role should be None after destroy.");
+        assert!(child_arc.lock().unwrap().parent.is_none(), "Child parent link should be None.");
+        assert!(!parent_arc.lock().unwrap().children.contains(&child_id), "Child should be removed from parent's children list.");
+    }
+
+    #[test]
+    fn test_parent_destruction_unmaps_children() {
+        let mut registry = SurfaceRegistry::new();
+        let mut buffer_manager = BufferManager::new(); // Needed for unregister_surface
+
+        let (parent_id, _) = create_surface_in_registry(&mut registry);
+        let (child1_id, child1_arc) = create_surface_in_registry(&mut registry);
+        let (child2_id, child2_arc) = create_surface_in_registry(&mut registry);
+
+        get_subsurface(0,0, child1_id, parent_id, &registry).unwrap();
+        get_subsurface(0,0, child2_id, parent_id, &registry).unwrap();
+
+        assert!(child1_arc.lock().unwrap().parent.is_some());
+        assert!(child2_arc.lock().unwrap().parent.is_some());
+
+        // Unregister (destroy) the parent surface
+        registry.unregister_surface(parent_id, &mut buffer_manager).unwrap();
+
+        // Children should still be in the registry but "orphaned" (parent=None)
+        // Their role as Subsurface might still exist but parent_id in SubsurfaceState would be sentinel.
+        let child1_surface = child1_arc.lock().unwrap();
+        assert!(child1_surface.parent.is_none(), "Child1 should be orphaned (parent=None).");
+        if let Some(SurfaceRole::Subsurface(ref state)) = child1_surface.role {
+            // The parent_id in SubsurfaceState is set to a new unique ID (sentinel)
+            // by prepare_for_destruction to signify it's no longer attached to the original parent.
+            assert_ne!(state.parent_id, parent_id, "Child1's SubsurfaceState.parent_id should not be the old parent_id.");
+        } else {
+            // Depending on exact logic in prepare_for_destruction, role might be cleared or state updated.
+            // Current prepare_for_destruction updates SubsurfaceState.parent_id.
+        }
+
+        let child2_surface = child2_arc.lock().unwrap();
+        assert!(child2_surface.parent.is_none(), "Child2 should be orphaned.");
+    }
+
+    #[test]
+    fn test_subsurface_set_position() {
+        let mut registry = SurfaceRegistry::new();
+        let (parent_id, _) = create_surface_in_registry(&mut registry);
+        let (child_id, child_arc) = create_surface_in_registry(&mut registry);
+        get_subsurface(0,0, child_id, parent_id, &registry).unwrap();
+
+        let result = set_position(child_id, 100, 50, &registry);
+        assert!(result.is_ok());
+
+        match &child_arc.lock().unwrap().role {
+            Some(SurfaceRole::Subsurface(state)) => {
+                assert_eq!(state.desired_position, (100,50));
+                // current_position would be updated on parent commit, not tested directly here yet.
+            }
+            _ => panic!("Not a subsurface"),
+        }
+    }
+
+    #[test]
+    fn test_subsurface_stacking() {
+        let mut registry = SurfaceRegistry::new();
+        let (p_id, p_arc) = create_surface_in_registry(&mut registry);
+        let (s1_id, _) = create_surface_in_registry(&mut registry);
+        let (s2_id, _) = create_surface_in_registry(&mut registry);
+        let (s3_id, _) = create_surface_in_registry(&mut registry);
+
+        get_subsurface(0,0,s1_id, p_id, &registry).unwrap(); // p -> [s1]
+        get_subsurface(0,0,s2_id, p_id, &registry).unwrap(); // p -> [s1, s2]
+        get_subsurface(0,0,s3_id, p_id, &registry).unwrap(); // p -> [s1, s2, s3]
+
+        assert_eq!(p_arc.lock().unwrap().children, vec![s1_id, s2_id, s3_id]);
+
+        // Place s1 above s2: s2, s1, s3
+        place_above(s1_id, s2_id, &registry).unwrap();
+        assert_eq!(p_arc.lock().unwrap().children, vec![s2_id, s1_id, s3_id], "s1 above s2");
+
+        // Place s3 below s2: s3, s2, s1
+        place_below(s3_id, s2_id, &registry).unwrap();
+        assert_eq!(p_arc.lock().unwrap().children, vec![s3_id, s2_id, s1_id], "s3 below s2");
+
+        // Place s1 above non-existent sibling (should go to top)
+        let non_existent_sibling = SurfaceId::new_unique();
+        place_above(s1_id, non_existent_sibling, &registry).unwrap();
+        assert_eq!(p_arc.lock().unwrap().children.last(), Some(&s1_id), "s1 at top due to invalid sibling");
+
+        // Place s2 below non-existent sibling (should go to bottom)
+        // Current order might be [s3, sX, s1] (sX is s2 from previous state)
+        // Let's reset for clarity for this part of test
+        p_arc.lock().unwrap().children = vec![s3_id, s1_id]; // s2 was removed by previous place_above
+        get_subsurface(0,0,s2_id, p_id, &registry).unwrap(); // re-add s2: [s3, s1, s2]
+        assert_eq!(p_arc.lock().unwrap().children, vec![s3_id, s1_id, s2_id]);
+
+        place_below(s2_id, non_existent_sibling, &registry).unwrap();
+        assert_eq!(p_arc.lock().unwrap().children.first(), Some(&s2_id), "s2 at bottom due to invalid sibling");
+    }
+
+    #[test]
+    fn test_subsurface_set_sync_desync() {
+        let mut registry = SurfaceRegistry::new();
+        let (parent_id, _) = create_surface_in_registry(&mut registry);
+        let (child_id, child_arc) = create_surface_in_registry(&mut registry);
+        get_subsurface(0,0, child_id, parent_id, &registry).unwrap();
+
+        // Default is Synchronized
+        match &child_arc.lock().unwrap().role {
+            Some(SurfaceRole::Subsurface(state)) => assert_eq!(state.sync_mode, SubsurfaceSyncMode::Synchronized),
+            _ => panic!(),
+        }
+
+        set_sync_mode(child_id, SubsurfaceSyncMode::Desynchronized, &registry).unwrap();
+        match &child_arc.lock().unwrap().role {
+            Some(SurfaceRole::Subsurface(state)) => assert_eq!(state.sync_mode, SubsurfaceSyncMode::Desynchronized),
+            _ => panic!(),
+        }
+
+        set_sync_mode(child_id, SubsurfaceSyncMode::Synchronized, &registry).unwrap();
+        match &child_arc.lock().unwrap().role {
+            Some(SurfaceRole::Subsurface(state)) => assert_eq!(state.sync_mode, SubsurfaceSyncMode::Synchronized),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn test_commit_synchronized_subsurface_caches_state() {
+        let mut registry = SurfaceRegistry::new();
+        let mut buffer_manager = BufferManager::new();
+        let client_id_val = ClientId::new(100);
+
+        let (parent_id, parent_arc) = create_surface_in_registry(&mut registry);
+        let (child_id, child_arc) = create_surface_in_registry(&mut registry);
+
+        // Make child a synchronized subsurface of parent
+        get_subsurface(0, 0, child_id, parent_id, &registry).unwrap();
+        set_sync_mode(child_id, SubsurfaceSyncMode::Synchronized, &registry).unwrap();
+
+        // Attach a buffer to the child surface
+        let buffer1 = buffer_manager.register_buffer(BufferType::Shm, 10, 10, 40, BufferFormat::Argb8888, Some(client_id_val));
+        let buffer1_id = buffer1.lock().unwrap().id;
+
+        {
+            let mut child_surface = child_arc.lock().unwrap();
+            child_surface.attach_buffer(&mut buffer_manager, Some(buffer1.clone()), client_id_val, 0, 0).unwrap();
+
+            // Commit the child (synchronized)
+            let commit_res = child_surface.commit(&mut buffer_manager);
+            assert!(commit_res.is_ok());
+
+            // Verify state is cached, not applied to current_buffer
+            assert!(child_surface.current_buffer.is_none(), "Child's current_buffer should be None before parent commit.");
+            assert!(child_surface.cached_pending_buffer.is_some(), "Child's cached_pending_buffer should be Some.");
+            assert_eq!(child_surface.cached_pending_buffer.as_ref().unwrap().lock().unwrap().id, buffer1_id);
+            assert!(child_surface.cached_pending_attributes.is_some());
+            assert_eq!(child_surface.cached_pending_attributes.unwrap().size, (10,10));
+
+            match &child_surface.role {
+                Some(SurfaceRole::Subsurface(state)) => {
+                    assert!(state.needs_apply_on_parent_commit, "needs_apply_on_parent_commit should be true.");
+                }
+                _ => panic!("Child not a subsurface"),
+            }
+        }
+
+        // Simulate parent committing (which would lead to this call for the child)
+        {
+            let mut child_surface = child_arc.lock().unwrap();
+            let apply_res = child_surface.apply_cached_state_from_sync(&mut buffer_manager);
+            assert!(apply_res.is_ok());
+
+            assert!(child_surface.current_buffer.is_some(), "Child's current_buffer should be Some after apply_cached_state.");
+            assert_eq!(child_surface.current_buffer.as_ref().unwrap().lock().unwrap().id, buffer1_id);
+            assert!(child_surface.cached_pending_buffer.is_none(), "Cache should be cleared after apply.");
+            assert!(child_surface.cached_pending_attributes.is_none(), "Cache should be cleared after apply.");
+             match &child_surface.role {
+                Some(SurfaceRole::Subsurface(state)) => {
+                    assert!(!state.needs_apply_on_parent_commit, "needs_apply_on_parent_commit should be false after apply.");
+                }
+                _ => panic!("Child not a subsurface"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_commit_desynchronized_subsurface_applies_directly() {
+        let mut registry = SurfaceRegistry::new();
+        let mut buffer_manager = BufferManager::new();
+        let client_id_val = ClientId::new(101);
+
+        let (parent_id, _) = create_surface_in_registry(&mut registry);
+        let (child_id, child_arc) = create_surface_in_registry(&mut registry);
+
+        get_subsurface(0, 0, child_id, parent_id, &registry).unwrap();
+        set_sync_mode(child_id, SubsurfaceSyncMode::Desynchronized, &registry).unwrap();
+
+        let buffer1 = buffer_manager.register_buffer(BufferType::Shm, 20, 20, 80, BufferFormat::Argb8888, Some(client_id_val));
+        let buffer1_id = buffer1.lock().unwrap().id;
+
+        {
+            let mut child_surface = child_arc.lock().unwrap();
+            child_surface.attach_buffer(&mut buffer_manager, Some(buffer1.clone()), client_id_val, 0, 0).unwrap();
+
+            let commit_res = child_surface.commit(&mut buffer_manager);
+            assert!(commit_res.is_ok());
+
+            // Verify state is applied directly
+            assert!(child_surface.current_buffer.is_some(), "Child's current_buffer should be Some for desync.");
+            assert_eq!(child_surface.current_buffer.as_ref().unwrap().lock().unwrap().id, buffer1_id);
+            assert!(child_surface.cached_pending_buffer.is_none(), "Cache should be None for desync.");
+            assert!(child_surface.cached_pending_attributes.is_none(), "Cache should be None for desync.");
+
+            match &child_surface.role {
+                Some(SurfaceRole::Subsurface(state)) => {
+                    assert!(!state.needs_apply_on_parent_commit, "needs_apply_on_parent_commit should be false for desync.");
+                }
+                _ => panic!("Child not a subsurface"),
+            }
+        }
+    }
+}

--- a/novade-compositor-core/src/surface.rs
+++ b/novade-compositor-core/src/surface.rs
@@ -1,0 +1,1716 @@
+use novade_buffer_manager::{BufferManager, BufferDetails, BufferId, ClientId, BufferFormat};
+use std::sync::{Arc, Mutex};
+
+// Placeholder for Wayland output transform
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum WlOutputTransform {
+    Normal,
+    // Add other transform types as needed
+}
+
+// Placeholder for Mat3x3
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Mat3x3 {
+    pub m: [f32; 9],
+}
+
+impl Default for Mat3x3 {
+    fn default() -> Self {
+        Self {
+            m: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0], // Identity matrix
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::surface_registry::{SurfaceRegistry, SurfaceRegistryAccessor};
+    use crate::buffer_manager::{BufferManager, BufferDetails, BufferType, BufferFormat, ClientId};
+    use crate::subcompositor::SubsurfaceSyncMode;
+    use std::sync::atomic::Ordering;
+
+    // Helper to create a simple BufferManager for tests
+    fn test_buffer_manager() -> BufferManager {
+        BufferManager::new()
+    }
+
+    // Helper to create a simple SurfaceRegistry for tests
+    fn test_surface_registry() -> SurfaceRegistry {
+        SurfaceRegistry::new()
+    }
+
+    #[test]
+    fn test_unique_surface_ids() {
+        let id1 = SurfaceId::new_unique();
+        let id2 = SurfaceId::new_unique();
+        assert_ne!(id1, id2, "SurfaceId::new_unique should generate unique IDs.");
+    }
+
+    #[test]
+    fn test_surface_creation_defaults() {
+        let surface = Surface::new();
+        assert_eq!(surface.current_state, SurfaceState::Created, "Initial state should be Created.");
+        assert_eq!(surface.pending_attributes, SurfaceAttributes::default(), "Pending attributes should be default.");
+        assert_eq!(surface.current_attributes, SurfaceAttributes::default(), "Current attributes should be default.");
+        assert!(surface.pending_buffer.is_none(), "Pending buffer should be None initially.");
+        assert!(surface.current_buffer.is_none(), "Current buffer should be None initially.");
+        assert!(surface.cached_pending_buffer.is_none(), "Cached pending buffer should be None initially.");
+        assert!(surface.cached_pending_attributes.is_none(), "Cached pending attributes should be None initially.");
+        assert!(surface.children.is_empty(), "Children list should be empty initially.");
+        assert!(surface.parent.is_none(), "Parent should be None initially.");
+        assert!(surface.frame_callbacks.is_empty(), "Frame callbacks should be empty initially.");
+
+        let default_opaque_region = Region::new();
+        let default_input_region = Region::new();
+        assert_eq!(surface.opaque_region.as_ref().unwrap().rectangles, default_opaque_region.rectangles, "Opaque region should be default/empty.");
+        assert_eq!(surface.input_region.as_ref().unwrap().rectangles, default_input_region.rectangles, "Input region should be default/empty.");
+    }
+
+    #[test]
+    fn test_register_new_surface_in_registry() {
+        let mut registry = test_surface_registry();
+        let (id, surface_arc) = registry.register_new_surface();
+
+        assert_eq!(surface_arc.lock().unwrap().id, id, "Registered surface ID should match returned ID.");
+        assert!(registry.get_surface(id).is_some(), "Surface should be retrievable from registry.");
+        let retrieved_arc = registry.get_surface(id).unwrap();
+        assert!(Arc::ptr_eq(&surface_arc, &retrieved_arc), "Retrieved Arc should be the same as registered Arc.");
+    }
+
+    #[test]
+    fn test_get_surface_from_registry() {
+        let mut registry = test_surface_registry();
+        let (id, _) = registry.register_new_surface();
+
+        let retrieved_arc = registry.get_surface(id);
+        assert!(retrieved_arc.is_some(), "Should retrieve registered surface.");
+        assert_eq!(retrieved_arc.unwrap().lock().unwrap().id, id);
+
+        let non_existent_id = SurfaceId::new_unique();
+        assert!(registry.get_surface(non_existent_id).is_none(), "Should return None for non-existent surface.");
+    }
+
+    #[test]
+    fn test_unregister_surface_simple() {
+        let mut registry = test_surface_registry();
+        let mut buffer_manager = test_buffer_manager();
+        let (id, surface_arc) = registry.register_new_surface();
+
+        let client_id_val = ClientId::new(1);
+        let client_id = Some(client_id_val);
+        let buffer_details_arc = buffer_manager.register_buffer(BufferType::Shm, 10, 10, 40, BufferFormat::Argb8888, client_id);
+
+        {
+            let mut surface_guard = surface_arc.lock().unwrap();
+            surface_guard.attach_buffer(&mut buffer_manager, Some(buffer_details_arc.clone()), client_id_val, 0, 0).unwrap();
+            surface_guard.commit(&mut buffer_manager).unwrap();
+        }
+
+        assert_eq!(buffer_details_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 2);
+
+        let unregistered_surface_arc_opt = registry.unregister_surface(id, &mut buffer_manager);
+        assert!(unregistered_surface_arc_opt.is_some());
+        let unregistered_surface_arc = unregistered_surface_arc_opt.unwrap();
+        assert_eq!(unregistered_surface_arc.lock().unwrap().id, id);
+        assert!(registry.get_surface(id).is_none());
+
+        assert_eq!(buffer_details_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 1);
+        assert_eq!(unregistered_surface_arc.lock().unwrap().current_state, SurfaceState::Destroyed);
+    }
+
+    #[test]
+    fn test_attach_null_buffer() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id = ClientId::new(1);
+
+        assert_eq!(surface.pending_attributes.size, (0,0));
+
+        let result = surface.attach_buffer(&mut buffer_manager, None, client_id, 0, 0);
+        assert!(result.is_ok());
+        assert!(surface.pending_buffer.is_none());
+        assert_eq!(surface.current_state, SurfaceState::PendingBuffer);
+        assert_eq!(surface.pending_attributes.size, (0,0));
+
+        let commit_result = surface.commit(&mut buffer_manager);
+        assert!(commit_result.is_ok());
+        assert!(surface.current_buffer.is_none());
+        assert_eq!(surface.current_state, SurfaceState::Committed);
+        assert_eq!(surface.current_attributes.size, (0,0));
+    }
+
+    #[test]
+    fn test_attach_buffer_valid() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id_val = ClientId::new(1);
+        let client_id = Some(client_id_val);
+
+        let buffer_details_arc = buffer_manager.register_buffer(
+            BufferType::Shm, 64, 64, 256, BufferFormat::Argb8888, client_id
+        );
+        let buffer_id = buffer_details_arc.lock().unwrap().id;
+
+        let attach_result = surface.attach_buffer(&mut buffer_manager, Some(buffer_details_arc.clone()), client_id_val, 0, 0);
+        assert!(attach_result.is_ok());
+
+        assert!(surface.pending_buffer.is_some());
+        assert_eq!(surface.pending_buffer.as_ref().unwrap().lock().unwrap().id, buffer_id);
+        assert_eq!(surface.pending_attributes.size, (64,64));
+        assert_eq!(surface.pending_attributes.buffer_offset, (0,0));
+        assert_eq!(surface.current_state, SurfaceState::PendingBuffer);
+        assert_eq!(buffer_details_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn test_attach_buffer_invalid_offset() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id_val = ClientId::new(1);
+        let client_id = Some(client_id_val);
+
+        let buffer_details_arc = buffer_manager.register_buffer(
+            BufferType::Shm, 64, 64, 256, BufferFormat::Argb8888, client_id
+        );
+
+        let attach_result = surface.attach_buffer(&mut buffer_manager, Some(buffer_details_arc.clone()), client_id_val, 10, 5);
+        assert!(attach_result.is_err());
+        match attach_result.err().unwrap() {
+            BufferAttachError::InvalidBufferOffset => {},
+            e => panic!("Expected InvalidBufferOffset, got {:?}", e),
+        }
+        assert!(surface.pending_buffer.is_none());
+        assert_eq!(buffer_details_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_commit_simple_attributes() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+
+        surface.pending_attributes.alpha = 0.5;
+        surface.pending_attributes.buffer_scale = 2;
+
+        let commit_result = surface.commit(&mut buffer_manager);
+        assert!(commit_result.is_ok());
+
+        assert_eq!(surface.current_attributes.alpha, 0.5);
+        assert_eq!(surface.current_attributes.buffer_scale, 2);
+        assert_eq!(surface.current_attributes.size, (0,0));
+        assert_eq!(surface.current_state, SurfaceState::Committed);
+    }
+
+    #[test]
+    fn test_commit_buffer_attach() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id_val = ClientId::new(1);
+        let client_id = Some(client_id_val);
+
+        let buffer1_arc = buffer_manager.register_buffer(
+            BufferType::Shm, 32, 32, 128, BufferFormat::Argb8888, client_id
+        );
+        surface.attach_buffer(&mut buffer_manager, Some(buffer1_arc.clone()), client_id_val, 0, 0).unwrap();
+        surface.commit(&mut buffer_manager).unwrap();
+
+        assert!(surface.current_buffer.is_some());
+        assert_eq!(surface.current_buffer.as_ref().unwrap().lock().unwrap().id, buffer1_arc.lock().unwrap().id);
+        assert_eq!(surface.current_attributes.size, (32,32));
+        assert_eq!(buffer1_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 2);
+        assert_eq!(surface.current_state, SurfaceState::Committed);
+
+        let buffer2_arc = buffer_manager.register_buffer(
+            BufferType::Shm, 64, 64, 256, BufferFormat::Xrgb8888, client_id
+        );
+        surface.attach_buffer(&mut buffer_manager, Some(buffer2_arc.clone()), client_id_val, 0, 0).unwrap();
+        assert!(surface.pending_buffer.is_some());
+
+        let commit_result = surface.commit(&mut buffer_manager);
+        assert!(commit_result.is_ok());
+
+        assert!(surface.current_buffer.is_some());
+        assert_eq!(surface.current_buffer.as_ref().unwrap().lock().unwrap().id, buffer2_arc.lock().unwrap().id);
+        assert!(surface.pending_buffer.is_none());
+        assert_eq!(surface.current_attributes.size, (64,64));
+        assert_eq!(buffer1_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 1);
+        assert_eq!(buffer2_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 2);
+        assert_eq!(surface.current_state, SurfaceState::Committed);
+    }
+
+    #[test]
+    fn test_commit_validation_invalid_size_due_to_scale() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id_val = ClientId::new(1);
+        let client_id = Some(client_id_val);
+
+        let buffer_arc = buffer_manager.register_buffer(
+            BufferType::Shm, 63, 63, 63*4, BufferFormat::Argb8888, client_id
+        );
+        surface.attach_buffer(&mut buffer_manager, Some(buffer_arc.clone()), client_id_val, 0, 0).unwrap();
+
+        surface.pending_attributes.buffer_scale = 2;
+
+        let commit_result = surface.commit(&mut buffer_manager);
+        assert!(commit_result.is_err());
+        match commit_result.err().unwrap() {
+            CommitError::InvalidBufferSize => {},
+            e => panic!("Expected InvalidBufferSize, got {:?}", e),
+        }
+
+        assert!(surface.current_buffer.is_none());
+        assert_ne!(surface.current_attributes.buffer_scale, 2);
+        assert_eq!(buffer_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn test_damage_buffer_simple() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id_val = ClientId::new(1);
+        let buffer_arc = buffer_manager.register_buffer(BufferType::Shm, 100, 100, 400, BufferFormat::Argb8888, Some(client_id_val));
+        surface.attach_buffer(&mut buffer_manager, Some(buffer_arc.clone()), client_id_val, 0, 0).unwrap();
+
+        surface.damage_buffer(10, 10, 20, 20);
+        assert_eq!(surface.damage_tracker.pending_damage_buffer.len(), 1);
+        assert_eq!(surface.damage_tracker.pending_damage_buffer[0], Rectangle::new(10,10,20,20));
+
+        surface.commit(&mut buffer_manager).unwrap();
+        assert_eq!(surface.damage_tracker.current_damage.len(), 1);
+        let expected_damage_after_commit = Rectangle::new(10,10,20,20).clipped_to(&Rectangle::new(0,0,100,100));
+        assert_eq!(surface.damage_tracker.current_damage[0], expected_damage_after_commit);
+    }
+
+    #[test]
+    fn test_damage_surface_simple() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        surface.pending_attributes.size = (100,100);
+        surface.commit(&mut buffer_manager).unwrap();
+
+        surface.damage_surface(15, 15, 25, 25);
+        assert_eq!(surface.damage_tracker.pending_damage_surface.len(), 1);
+        assert_eq!(surface.damage_tracker.pending_damage_surface[0], Rectangle::new(15,15,25,25));
+
+        surface.commit(&mut buffer_manager).unwrap();
+        assert_eq!(surface.damage_tracker.current_damage.len(), 1);
+        let expected_damage_after_commit = Rectangle::new(15,15,25,25).clipped_to(&Rectangle::new(0,0,100,100));
+        assert_eq!(surface.damage_tracker.current_damage[0], expected_damage_after_commit);
+    }
+
+    #[test]
+    fn test_damage_commit_clears_pending() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        surface.pending_attributes.size = (100,100);
+        surface.commit(&mut buffer_manager).unwrap();
+
+        surface.damage_surface(10,10,20,20);
+        assert!(!surface.damage_tracker.pending_damage_surface.is_empty());
+
+        surface.commit(&mut buffer_manager).unwrap();
+        assert!(surface.damage_tracker.pending_damage_surface.is_empty());
+        assert!(surface.damage_tracker.pending_damage_buffer.is_empty());
+    }
+
+    #[test]
+    fn test_damage_buffer_transform_and_clip() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id_val = ClientId::new(1);
+
+        let buffer_arc = buffer_manager.register_buffer(BufferType::Shm, 200, 100, 800, BufferFormat::Argb8888, Some(client_id_val));
+        surface.attach_buffer(&mut buffer_manager, Some(buffer_arc.clone()), client_id_val, 0, 0).unwrap();
+
+        surface.pending_attributes.buffer_scale = 2;
+
+        surface.damage_buffer(40, 20, 80, 40);
+
+        surface.commit(&mut buffer_manager).unwrap();
+
+        assert_eq!(surface.current_attributes.size, (100,50));
+        assert_eq!(surface.damage_tracker.current_damage.len(), 1);
+
+        let expected_rect = Rectangle::new(20, 10, 40, 20);
+        let clipped_expected = expected_rect.clipped_to(&Rectangle::new(0,0,100,50));
+        assert_eq!(surface.damage_tracker.current_damage[0], clipped_expected);
+
+        surface.damage_buffer(180, 80, 40, 30);
+        surface.commit(&mut buffer_manager).unwrap();
+        assert_eq!(surface.damage_tracker.current_damage.len(), 1);
+        let expected_rect2 = Rectangle::new(90,40,20,15);
+        let clipped_expected2 = expected_rect2.clipped_to(&Rectangle::new(0,0,100,50));
+        assert_eq!(clipped_expected2, Rectangle::new(90,40,10,10));
+        assert_eq!(surface.damage_tracker.current_damage[0], clipped_expected2);
+    }
+
+    #[test]
+    fn test_damage_overflow_fallback() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        surface.pending_attributes.size = (100,100);
+        surface.commit(&mut buffer_manager).unwrap();
+
+        surface.damage_surface(0,0,100,76);
+        surface.commit(&mut buffer_manager).unwrap();
+
+        assert_eq!(surface.damage_tracker.current_damage.len(), 1);
+        assert_eq!(surface.damage_tracker.current_damage[0], Rectangle::new(0,0,100,100));
+    }
+
+    #[test]
+    fn test_damage_age_reset_on_new_content_commit() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id_val = ClientId::new(1);
+
+        surface.pending_attributes.size = (50,50);
+        surface.commit(&mut buffer_manager).unwrap();
+
+        surface.damage_surface(0,0,10,10);
+        assert_eq!(surface.damage_tracker.damage_age, 1);
+        surface.commit(&mut buffer_manager).unwrap();
+        assert_eq!(surface.damage_tracker.damage_age, 1);
+
+        surface.damage_surface(0,0,10,10);
+        assert_eq!(surface.damage_tracker.damage_age, 2);
+
+        let buffer_arc = buffer_manager.register_buffer(BufferType::Shm, 50, 50, 200, BufferFormat::Argb8888, Some(client_id_val));
+        surface.attach_buffer(&mut buffer_manager, Some(buffer_arc), client_id_val, 0, 0).unwrap();
+        surface.commit(&mut buffer_manager).unwrap();
+
+        assert_eq!(surface.damage_tracker.damage_age, 0);
+    }
+
+    #[test]
+    fn test_frame_callback_registration() {
+        let mut surface = Surface::new();
+        assert!(surface.frame_callbacks.is_empty());
+        surface.frame(123);
+        assert_eq!(surface.frame_callbacks.len(), 1);
+        assert_eq!(surface.frame_callbacks[0].id, 123);
+        surface.frame(456);
+        assert_eq!(surface.frame_callbacks.len(), 2);
+        assert_eq!(surface.frame_callbacks[1].id, 456);
+    }
+
+    #[test]
+    fn test_take_frame_callbacks() {
+        let mut surface = Surface::new();
+        surface.frame(1);
+        surface.frame(2);
+
+        let taken_callbacks = surface.take_frame_callbacks();
+        assert_eq!(taken_callbacks.len(), 2);
+        assert_eq!(taken_callbacks[0].id, 1);
+        assert_eq!(taken_callbacks[1].id, 2);
+        assert!(surface.frame_callbacks.is_empty());
+
+        let taken_again = surface.take_frame_callbacks();
+        assert!(taken_again.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::surface_registry::{SurfaceRegistry, SurfaceRegistryAccessor};
+    use crate::buffer_manager::{BufferManager, BufferDetails, BufferType, BufferFormat, ClientId};
+    use crate::subcompositor::SubsurfaceSyncMode; // For later tests
+    use std::sync::atomic::Ordering;
+
+    // Helper to create a simple BufferManager for tests
+    fn test_buffer_manager() -> BufferManager {
+        BufferManager::new()
+    }
+
+    // Helper to create a simple SurfaceRegistry for tests
+    fn test_surface_registry() -> SurfaceRegistry {
+        SurfaceRegistry::new()
+    }
+
+    #[test]
+    fn test_unique_surface_ids() {
+        let id1 = SurfaceId::new_unique();
+        let id2 = SurfaceId::new_unique();
+        assert_ne!(id1, id2, "SurfaceId::new_unique should generate unique IDs.");
+    }
+
+    #[test]
+    fn test_surface_creation_defaults() {
+        let surface = Surface::new();
+        assert_eq!(surface.current_state, SurfaceState::Created, "Initial state should be Created.");
+        assert_eq!(surface.pending_attributes, SurfaceAttributes::default(), "Pending attributes should be default.");
+        assert_eq!(surface.current_attributes, SurfaceAttributes::default(), "Current attributes should be default.");
+        assert!(surface.pending_buffer.is_none(), "Pending buffer should be None initially.");
+        assert!(surface.current_buffer.is_none(), "Current buffer should be None initially.");
+        assert!(surface.cached_pending_buffer.is_none(), "Cached pending buffer should be None initially.");
+        assert!(surface.cached_pending_attributes.is_none(), "Cached pending attributes should be None initially.");
+        assert!(surface.children.is_empty(), "Children list should be empty initially.");
+        assert!(surface.parent.is_none(), "Parent should be None initially.");
+        assert!(surface.frame_callbacks.is_empty(), "Frame callbacks should be empty initially.");
+
+        let default_opaque_region = Region::new(); // Assuming default region is empty or defined
+        let default_input_region = Region::new();
+        assert_eq!(surface.opaque_region.as_ref().unwrap().rectangles, default_opaque_region.rectangles, "Opaque region should be default/empty.");
+        assert_eq!(surface.input_region.as_ref().unwrap().rectangles, default_input_region.rectangles, "Input region should be default/empty.");
+    }
+
+    #[test]
+    fn test_register_new_surface_in_registry() {
+        let mut registry = test_surface_registry();
+        let (id, surface_arc) = registry.register_new_surface();
+
+        assert_eq!(surface_arc.lock().unwrap().id, id, "Registered surface ID should match returned ID.");
+        assert!(registry.get_surface(id).is_some(), "Surface should be retrievable from registry.");
+        let retrieved_arc = registry.get_surface(id).unwrap();
+        assert!(Arc::ptr_eq(&surface_arc, &retrieved_arc), "Retrieved Arc should be the same as registered Arc.");
+    }
+
+    #[test]
+    fn test_get_surface_from_registry() {
+        let mut registry = test_surface_registry();
+        let (id, _) = registry.register_new_surface();
+
+        let retrieved_arc = registry.get_surface(id);
+        assert!(retrieved_arc.is_some(), "Should retrieve registered surface.");
+        assert_eq!(retrieved_arc.unwrap().lock().unwrap().id, id);
+
+        let non_existent_id = SurfaceId::new_unique();
+        assert!(registry.get_surface(non_existent_id).is_none(), "Should return None for non-existent surface.");
+    }
+
+    #[test]
+    fn test_unregister_surface_simple() {
+        let mut registry = test_surface_registry();
+        let mut buffer_manager = test_buffer_manager();
+        let (id, surface_arc) = registry.register_new_surface();
+
+        let client_id_val = ClientId::new(1);
+        let client_id = Some(client_id_val);
+        let buffer_details_arc = buffer_manager.register_buffer(BufferType::Shm, 10, 10, 40, BufferFormat::Argb8888, client_id);
+
+        // Attach and commit buffer to surface
+        {
+            let mut surface_guard = surface_arc.lock().unwrap();
+            surface_guard.attach_buffer(&mut buffer_manager, Some(buffer_details_arc.clone()), client_id_val, 0, 0).unwrap();
+            surface_guard.commit(&mut buffer_manager).unwrap();
+        }
+
+        assert_eq!(buffer_details_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 2, "Buffer ref count should be 2 (manager + surface).");
+
+        let unregistered_surface_arc_opt = registry.unregister_surface(id, &mut buffer_manager);
+        assert!(unregistered_surface_arc_opt.is_some(), "Unregister should return the surface.");
+        let unregistered_surface_arc = unregistered_surface_arc_opt.unwrap();
+        assert_eq!(unregistered_surface_arc.lock().unwrap().id, id);
+        assert!(registry.get_surface(id).is_none(), "Surface should be removed from registry after unregister.");
+
+        assert_eq!(buffer_details_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 1, "Buffer ref count should be 1 (manager only) after surface unregister.");
+
+        assert_eq!(unregistered_surface_arc.lock().unwrap().current_state, SurfaceState::Destroyed, "Surface state should be Destroyed.");
+    }
+
+    #[test]
+    fn test_attach_null_buffer() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id = ClientId::new(1);
+
+        // Initial size check
+        assert_eq!(surface.pending_attributes.size, (0,0), "Initial pending size should be (0,0).");
+
+        let result = surface.attach_buffer(&mut buffer_manager, None, client_id, 0, 0);
+        assert!(result.is_ok(), "Attaching NULL buffer should be Ok.");
+        assert!(surface.pending_buffer.is_none(), "Pending buffer should be None after attaching NULL.");
+        assert_eq!(surface.current_state, SurfaceState::PendingBuffer, "Surface state should be PendingBuffer after attach(NULL).");
+
+        // Check that pending_attributes.size is not changed by attach(NULL)
+        assert_eq!(surface.pending_attributes.size, (0,0), "Pending size should remain (0,0) after attach(NULL) if not previously set by a real buffer.");
+
+        let commit_result = surface.commit(&mut buffer_manager);
+        assert!(commit_result.is_ok(), "Commit after attach(NULL) should be Ok.");
+        assert!(surface.current_buffer.is_none(), "Current buffer should be None after commit of NULL buffer.");
+        assert_eq!(surface.current_state, SurfaceState::Committed, "Surface state should be Committed.");
+        assert_eq!(surface.current_attributes.size, (0,0), "Current size should be (0,0) after commit of attach(NULL).");
+    }
+
+    #[test]
+    fn test_attach_buffer_valid() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id_val = ClientId::new(1);
+        let client_id = Some(client_id_val);
+
+        let buffer_details_arc = buffer_manager.register_buffer(
+            BufferType::Shm, 64, 64, 256, BufferFormat::Argb8888, client_id
+        );
+        let buffer_id = buffer_details_arc.lock().unwrap().id;
+
+        let attach_result = surface.attach_buffer(&mut buffer_manager, Some(buffer_details_arc.clone()), client_id_val, 0, 0);
+        assert!(attach_result.is_ok());
+
+        assert!(surface.pending_buffer.is_some(), "Pending buffer should be Some.");
+        assert_eq!(surface.pending_buffer.as_ref().unwrap().lock().unwrap().id, buffer_id, "Correct buffer should be pending.");
+        assert_eq!(surface.pending_attributes.size, (64,64), "Pending attributes size should be updated to buffer size.");
+        assert_eq!(surface.pending_attributes.buffer_offset, (0,0), "Pending buffer offset should be set.");
+        assert_eq!(surface.current_state, SurfaceState::PendingBuffer, "Surface state should be PendingBuffer.");
+        assert_eq!(buffer_details_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 2, "Buffer ref count should be incremented to 2.");
+    }
+
+    #[test]
+    fn test_attach_buffer_invalid_offset() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id_val = ClientId::new(1);
+        let client_id = Some(client_id_val);
+
+        let buffer_details_arc = buffer_manager.register_buffer(
+            BufferType::Shm, 64, 64, 256, BufferFormat::Argb8888, client_id
+        );
+
+        let attach_result = surface.attach_buffer(&mut buffer_manager, Some(buffer_details_arc.clone()), client_id_val, 10, 5); // Non-zero offset
+        assert!(attach_result.is_err(), "Attaching with non-zero offset should fail.");
+        match attach_result.err().unwrap() {
+            BufferAttachError::InvalidBufferOffset => { /* Correct error */ },
+            e => panic!("Expected InvalidBufferOffset, got {:?}", e),
+        }
+        assert!(surface.pending_buffer.is_none(), "Pending buffer should remain None after failed attach.");
+        assert_eq!(buffer_details_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 1, "Buffer ref count should not change on failed attach.");
+    }
+
+    #[test]
+    fn test_commit_simple_attributes() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+
+        surface.pending_attributes.alpha = 0.5;
+        surface.pending_attributes.buffer_scale = 2;
+        // Note: Size is (0,0) by default and no buffer is attached.
+
+        let commit_result = surface.commit(&mut buffer_manager);
+        assert!(commit_result.is_ok());
+
+        assert_eq!(surface.current_attributes.alpha, 0.5);
+        assert_eq!(surface.current_attributes.buffer_scale, 2);
+        assert_eq!(surface.current_attributes.size, (0,0)); // Size doesn't change without buffer
+        assert_eq!(surface.current_state, SurfaceState::Committed);
+    }
+
+    #[test]
+    fn test_commit_buffer_attach() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id_val = ClientId::new(1);
+        let client_id = Some(client_id_val);
+
+        // First buffer
+        let buffer1_arc = buffer_manager.register_buffer(
+            BufferType::Shm, 32, 32, 128, BufferFormat::Argb8888, client_id
+        );
+        surface.attach_buffer(&mut buffer_manager, Some(buffer1_arc.clone()), client_id_val, 0, 0).unwrap();
+        surface.commit(&mut buffer_manager).unwrap();
+
+        assert!(surface.current_buffer.is_some(), "Current buffer should be set after first commit.");
+        assert_eq!(surface.current_buffer.as_ref().unwrap().lock().unwrap().id, buffer1_arc.lock().unwrap().id);
+        assert_eq!(surface.current_attributes.size, (32,32));
+        assert_eq!(buffer1_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 2, "Buffer1 ref count should be 2.");
+        assert_eq!(surface.current_state, SurfaceState::Committed);
+
+        // Attach a second buffer
+        let buffer2_arc = buffer_manager.register_buffer(
+            BufferType::Shm, 64, 64, 256, BufferFormat::Xrgb8888, client_id
+        );
+        surface.attach_buffer(&mut buffer_manager, Some(buffer2_arc.clone()), client_id_val, 0, 0).unwrap();
+        assert!(surface.pending_buffer.is_some());
+
+        let commit_result = surface.commit(&mut buffer_manager);
+        assert!(commit_result.is_ok());
+
+        assert!(surface.current_buffer.is_some(), "Current buffer should be updated to buffer2.");
+        assert_eq!(surface.current_buffer.as_ref().unwrap().lock().unwrap().id, buffer2_arc.lock().unwrap().id);
+        assert!(surface.pending_buffer.is_none(), "Pending buffer should be None after commit.");
+        assert_eq!(surface.current_attributes.size, (64,64), "Current attributes size should reflect buffer2.");
+        assert_eq!(buffer1_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 1, "Buffer1 ref count should be 1 (released by surface).");
+        assert_eq!(buffer2_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 2, "Buffer2 ref count should be 2.");
+        assert_eq!(surface.current_state, SurfaceState::Committed);
+    }
+
+    #[test]
+    fn test_commit_validation_invalid_size_due_to_scale() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id_val = ClientId::new(1);
+        let client_id = Some(client_id_val);
+
+        let buffer_arc = buffer_manager.register_buffer(
+            BufferType::Shm, 63, 63, 63*4, BufferFormat::Argb8888, client_id // Dimensions not divisible by 2
+        );
+        surface.attach_buffer(&mut buffer_manager, Some(buffer_arc.clone()), client_id_val, 0, 0).unwrap();
+
+        // Set a scale that makes the buffer size invalid
+        surface.pending_attributes.buffer_scale = 2;
+        // Buffer width 63 % scale 2 != 0
+
+        let commit_result = surface.commit(&mut buffer_manager);
+        assert!(commit_result.is_err(), "Commit should fail due to invalid size with scale.");
+        match commit_result.err().unwrap() {
+            CommitError::InvalidBufferSize => { /* Correct error */ },
+            e => panic!("Expected InvalidBufferSize, got {:?}", e),
+        }
+
+        // Ensure state was not applied
+        assert!(surface.current_buffer.is_none(), "Current buffer should not be set on failed commit.");
+        assert_ne!(surface.current_attributes.buffer_scale, 2, "Buffer scale should not be applied on failed commit.");
+        assert_eq!(buffer_arc.lock().unwrap().ref_count.load(Ordering::SeqCst), 2, "Buffer ref count should still be 2 (pending on surface).");
+    }
+
+    // --- Damage Tracking Tests ---
+    #[test]
+    fn test_damage_buffer_simple() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id_val = ClientId::new(1);
+        // Attach a buffer so damage can be applied relative to it
+        let buffer_arc = buffer_manager.register_buffer(BufferType::Shm, 100, 100, 400, BufferFormat::Argb8888, Some(client_id_val));
+        surface.attach_buffer(&mut buffer_manager, Some(buffer_arc.clone()), client_id_val, 0, 0).unwrap();
+
+        surface.damage_buffer(10, 10, 20, 20);
+        assert_eq!(surface.damage_tracker.pending_damage_buffer.len(), 1);
+        assert_eq!(surface.damage_tracker.pending_damage_buffer[0], Rectangle::new(10,10,20,20));
+
+        surface.commit(&mut buffer_manager).unwrap();
+        assert_eq!(surface.damage_tracker.current_damage.len(), 1);
+        // Assuming scale=1, transform=Normal for simplicity here.
+        // Transformed and clipped rect will be tested separately.
+        let expected_damage_after_commit = Rectangle::new(10,10,20,20).clipped_to(&Rectangle::new(0,0,100,100));
+        assert_eq!(surface.damage_tracker.current_damage[0], expected_damage_after_commit);
+    }
+
+    #[test]
+    fn test_damage_surface_simple() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        // Set a surface size for surface damage to be relative to
+        surface.pending_attributes.size = (100,100);
+        surface.commit(&mut buffer_manager).unwrap(); // Commit size
+
+        surface.damage_surface(15, 15, 25, 25);
+        assert_eq!(surface.damage_tracker.pending_damage_surface.len(), 1);
+        assert_eq!(surface.damage_tracker.pending_damage_surface[0], Rectangle::new(15,15,25,25));
+
+        surface.commit(&mut buffer_manager).unwrap();
+        assert_eq!(surface.damage_tracker.current_damage.len(), 1);
+        let expected_damage_after_commit = Rectangle::new(15,15,25,25).clipped_to(&Rectangle::new(0,0,100,100));
+        assert_eq!(surface.damage_tracker.current_damage[0], expected_damage_after_commit);
+    }
+
+    #[test]
+    fn test_damage_commit_clears_pending() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        surface.pending_attributes.size = (100,100); // Give surface a size
+        surface.commit(&mut buffer_manager).unwrap();
+
+
+        surface.damage_surface(10,10,20,20);
+        assert!(!surface.damage_tracker.pending_damage_surface.is_empty());
+
+        surface.commit(&mut buffer_manager).unwrap();
+        assert!(surface.damage_tracker.pending_damage_surface.is_empty(), "Pending surface damage should be cleared after commit.");
+        assert!(surface.damage_tracker.pending_damage_buffer.is_empty(), "Pending buffer damage should be cleared after commit (even if none was added).");
+    }
+
+    #[test]
+    fn test_damage_buffer_transform_and_clip() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id_val = ClientId::new(1);
+
+        let buffer_arc = buffer_manager.register_buffer(BufferType::Shm, 200, 100, 800, BufferFormat::Argb8888, Some(client_id_val));
+        surface.attach_buffer(&mut buffer_manager, Some(buffer_arc.clone()), client_id_val, 0, 0).unwrap();
+
+        // Surface attributes for transform: scale = 2
+        // Buffer is 200x100. Surface will be 100x50.
+        surface.pending_attributes.buffer_scale = 2;
+        // No wl_output_transform for this test, just scale.
+
+        // Damage in buffer coordinates
+        surface.damage_buffer(40, 20, 80, 40); // This corresponds to (20,10,40,20) in surface coords
+
+        surface.commit(&mut buffer_manager).unwrap();
+
+        assert_eq!(surface.current_attributes.size, (100,50)); // Verifying surface size after scale
+        assert_eq!(surface.damage_tracker.current_damage.len(), 1, "Expected 1 damage rect after commit.");
+
+        // Expected damage in surface coordinates:
+        // x = 40/2 = 20
+        // y = 20/2 = 10
+        // width = 80/2 = 40
+        // height = 40/2 = 20
+        let expected_rect = Rectangle::new(20, 10, 40, 20);
+        // Clipped to surface size 100x50 (which it is within)
+        let clipped_expected = expected_rect.clipped_to(&Rectangle::new(0,0,100,50));
+
+        assert_eq!(surface.damage_tracker.current_damage[0], clipped_expected);
+
+        // Test clipping: damage partially outside scaled buffer dimensions
+        surface.damage_buffer(180, 80, 40, 30); // In buffer: (180,80,40,30). Scaled: (90,40,20,15)
+                                               // Surface size: 100x50.
+        surface.commit(&mut buffer_manager).unwrap();
+        assert_eq!(surface.damage_tracker.current_damage.len(), 1);
+        let expected_rect2 = Rectangle::new(90,40,20,15);
+        let clipped_expected2 = expected_rect2.clipped_to(&Rectangle::new(0,0,100,50));
+        // Expected: x=90, y=40, w=10 (clipped from 20), h=10 (clipped from 15)
+        assert_eq!(clipped_expected2, Rectangle::new(90,40,10,10));
+        assert_eq!(surface.damage_tracker.current_damage[0], clipped_expected2);
+    }
+
+    #[test]
+    fn test_damage_overflow_fallback() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        surface.pending_attributes.size = (100,100);
+        surface.commit(&mut buffer_manager).unwrap();
+
+        // Add more damage rects than MAX_DAMAGE_RECTS (assuming MAX_DAMAGE_RECTS is small for test, e.g. 3)
+        // Or, check if DamageTracker::MAX_DAMAGE_RECTS can be set for testing.
+        // For now, simulate by adding rects that cover > 75% area.
+        surface.damage_surface(0,0,100,76); // 76% area
+        surface.commit(&mut buffer_manager).unwrap();
+
+        assert_eq!(surface.damage_tracker.current_damage.len(), 1, "Damage should fallback to 1 rect.");
+        assert_eq!(surface.damage_tracker.current_damage[0], Rectangle::new(0,0,100,100), "Damage should be full surface.");
+    }
+
+    #[test]
+    fn test_damage_age_reset_on_new_content_commit() {
+        let mut surface = Surface::new();
+        let mut buffer_manager = test_buffer_manager();
+        let client_id_val = ClientId::new(1);
+
+        surface.pending_attributes.size = (50,50);
+        surface.commit(&mut buffer_manager).unwrap(); // Initial commit, sets size
+
+        surface.damage_surface(0,0,10,10); // damage_age becomes 1
+        assert_eq!(surface.damage_tracker.damage_age, 1);
+        surface.commit(&mut buffer_manager).unwrap(); // Commit damage, no new buffer, age should persist (or handled by renderer)
+                                                      // Current logic in DamageTracker::commit_pending_damage resets age if new_buffer_committed.
+                                                      // new_content_committed in Surface::commit is false here. So age should NOT reset.
+        assert_eq!(surface.damage_tracker.damage_age, 1); // DamageTracker.commit called with new_buffer_committed=false
+
+        surface.damage_surface(0,0,10,10); // damage_age becomes 2
+        assert_eq!(surface.damage_tracker.damage_age, 2);
+
+        // Now attach a new buffer (new content)
+        let buffer_arc = buffer_manager.register_buffer(BufferType::Shm, 50, 50, 200, BufferFormat::Argb8888, Some(client_id_val));
+        surface.attach_buffer(&mut buffer_manager, Some(buffer_arc), client_id_val, 0, 0).unwrap();
+        surface.commit(&mut buffer_manager).unwrap(); // new_content_committed will be true
+
+        assert_eq!(surface.damage_tracker.damage_age, 0, "Damage age should reset on new buffer commit.");
+    }
+
+    // --- Frame Callback Tests ---
+    #[test]
+    fn test_frame_callback_registration() {
+        let mut surface = Surface::new();
+        assert!(surface.frame_callbacks.is_empty());
+        surface.frame(123);
+        assert_eq!(surface.frame_callbacks.len(), 1);
+        assert_eq!(surface.frame_callbacks[0].id, 123);
+        surface.frame(456);
+        assert_eq!(surface.frame_callbacks.len(), 2);
+        assert_eq!(surface.frame_callbacks[1].id, 456);
+    }
+
+    #[test]
+    fn test_take_frame_callbacks() {
+        let mut surface = Surface::new();
+        surface.frame(1);
+        surface.frame(2);
+
+        let taken_callbacks = surface.take_frame_callbacks();
+        assert_eq!(taken_callbacks.len(), 2);
+        assert_eq!(taken_callbacks[0].id, 1);
+        assert_eq!(taken_callbacks[1].id, 2);
+        assert!(surface.frame_callbacks.is_empty(), "Internal frame_callbacks list should be empty after take.");
+
+        let taken_again = surface.take_frame_callbacks();
+        assert!(taken_again.is_empty(), "Taking callbacks again should yield an empty list.");
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SurfaceId(u64);
+
+impl SurfaceId {
+    // Basic ID generation, can be improved later
+    pub fn new_unique() -> Self { // Made public for potential external use if needed
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+        SurfaceId(NEXT_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurfaceState {
+    Created,
+    PendingBuffer,
+    Committed,
+    Rendering,
+    Presented,
+    Destroyed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SurfaceAttributes {
+    pub position: (i32, i32),
+    pub size: (u32, u32),
+    pub transform: Mat3x3,
+    pub alpha: f32,
+    pub buffer_scale: i32,
+    pub buffer_transform: WlOutputTransform,
+    pub buffer_offset: (i32, i32), // For wl_surface.attach dx, dy
+}
+
+impl Default for SurfaceAttributes {
+    fn default() -> Self {
+        Self {
+            position: (0, 0),
+            size: (0, 0),
+            transform: Mat3x3::default(),
+            alpha: 1.0,
+            buffer_scale: 1,
+            buffer_transform: WlOutputTransform::Normal,
+            buffer_offset: (0, 0),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)] // Added Eq, Hash for potential use in sets
+pub struct Rectangle {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+impl Rectangle {
+    pub fn new(x: i32, y: i32, width: i32, height: i32) -> Self {
+        Self { x, y, width, height }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.width <= 0 || self.height <= 0
+    }
+
+    pub fn area(&self) -> i32 {
+        if self.is_empty() {
+            0
+        } else {
+            self.width * self.height
+        }
+    }
+
+    pub fn intersects(&self, other: &Self) -> bool {
+        if self.is_empty() || other.is_empty() {
+            return false;
+        }
+        self.x < other.x + other.width &&
+        self.x + self.width > other.x &&
+        self.y < other.y + other.height &&
+        self.y + self.height > other.y
+    }
+
+    pub fn union(&self, other: &Self) -> Self {
+        if self.is_empty() {
+            return *other;
+        }
+        if other.is_empty() {
+            return *self;
+        }
+
+        let x1 = self.x.min(other.x);
+        let y1 = self.y.min(other.y);
+        let x2 = (self.x + self.width).max(other.x + other.width);
+        let y2 = (self.y + self.height).max(other.y + other.height);
+
+        Self { x: x1, y: y1, width: x2 - x1, height: y2 - y1 }
+    }
+
+    pub fn intersection(&self, other: &Self) -> Self {
+        if !self.intersects(other) {
+            return Self { x: 0, y: 0, width: 0, height: 0 }; // Empty rectangle
+        }
+
+        let x1 = self.x.max(other.x);
+        let y1 = self.y.max(other.y);
+        let x2 = (self.x + self.width).min(other.x + other.width);
+        let y2 = (self.y + self.height).min(other.y + other.height);
+
+        Self { x: x1, y: y1, width: x2 - x1, height: y2 - y1 }
+    }
+
+    // Clip this rectangle against another (clipping_rect).
+    // Returns a new rectangle that is the part of this rectangle within clipping_rect.
+    pub fn clipped_to(&self, clipping_rect: &Self) -> Self {
+        self.intersection(clipping_rect)
+    }
+
+    // Translates the rectangle by (dx, dy)
+    pub fn translate(&self, dx: i32, dy: i32) -> Self {
+        Self { x: self.x + dx, y: self.y + dy, width: self.width, height: self.height }
+    }
+
+    // Scales the rectangle.
+    pub fn scale(&self, factor: i32) -> Self {
+        if factor == 0 { return Self::new(0,0,0,0); }
+        if factor == 1 { return *self; } // No change
+        Self {
+            x: self.x / factor, // Integer division, as per wl_surface rules for buffer_scale
+            y: self.y / factor,
+            width: self.width / factor,
+            height: self.height / factor,
+        }
+    }
+
+    // Applies wl_output transform to a point.
+    // `surface_width` and `surface_height` are the dimensions of the surface *before* this transform is applied,
+    // but *after* scaling.
+    fn transform_point(x: i32, y: i32, transform: WlOutputTransform, s_width: i32, s_height: i32) -> (i32, i32) {
+        match transform {
+            WlOutputTransform::Normal => (x, y),
+            WlOutputTransform::Rotated90 => (s_height - y - 1, x), // (y, surface_width - x -1) but map to new coordinate space origin
+                                                                // More standard: (y, old_sw - x -1) then map to new origin.
+                                                                // Let's use a simpler mapping: (old_y, new_sw - old_x -1) -> (y, s_width - x -1)
+                                                                // No, Wayland spec: (surface_height - y_buffer - 1, x_buffer) for 90 deg
+                                                                // This implies coordinates are flipped then translated.
+                                                                // For rects, it's more complex.
+                                                                // Simpler: x' = y_buffer, y' = surface_width_untransformed - (x_buffer + width_buffer)
+                                                                // For points: x_surf = y_buff, y_surf = s_w - x_buff -1 (if s_w is original width)
+                                                                // This is complex. Sticking to rect transform for now.
+            // TODO: Implement other transforms for points if necessary for advanced rect transformation.
+            _ => (x,y) // Fallback for unimplemented transforms
+        }
+    }
+
+
+    // Transforms the rectangle according to wl_output::Transform.
+    // `s_width` and `s_height` are the surface dimensions *before* this transform is applied (i.e. buffer_w/scale, buffer_h/scale)
+    pub fn transform(&self, transform: WlOutputTransform, s_width: i32, s_height: i32) -> Self {
+        let mut new_x = self.x;
+        let mut new_y = self.y;
+        let mut new_width = self.width;
+        let mut new_height = self.height;
+
+        match transform {
+            WlOutputTransform::Normal => { /* No change */ }
+            WlOutputTransform::Rotated90 => {
+                new_x = self.y;
+                new_y = s_width - (self.x + self.width);
+                new_width = self.height;
+                new_height = self.width;
+            }
+            WlOutputTransform::Rotated180 => {
+                new_x = s_width - (self.x + self.width);
+                new_y = s_height - (self.y + self.height);
+            }
+            WlOutputTransform::Rotated270 => {
+                new_x = s_height - (self.y + self.height);
+                new_y = self.x;
+                new_width = self.height;
+                new_height = self.width;
+            }
+            WlOutputTransform::Flipped => { // Flipped horizontally
+                new_x = s_width - (self.x + self.width);
+            }
+            WlOutputTransform::FlippedRotated90 => { // Flipped horizontally, then Rotated90
+                // Original: (x, y, w, h)
+                // Flipped: (s_w - (x+w), y, w, h)
+                // Rotated90 from Flipped:
+                // new_x = y_flipped = y
+                // new_y = s_width_of_flipped_surface - (x_flipped + w_flipped)
+                //       = s_width - ( (s_width - (x+w)) + w) = s_width - (s_width - x) = x
+                new_x = self.y; // y from original
+                new_y = s_width - ( (s_width - (self.x + self.width)) + self.width); // This is s_width - (s_width - self.x) = self.x
+                new_width = self.height;
+                new_height = self.width;
+            }
+            WlOutputTransform::FlippedRotated180 => { // Flipped horizontally, then Rotated180 (Vertical Flip)
+                new_x = self.x; // x is flipped, then flipped back by 180 rot.
+                new_y = s_height - (self.y + self.height); // y is not changed by horiz_flip, then flipped by 180 rot.
+            }
+            WlOutputTransform::FlippedRotated270 => { // Flipped horizontally, then Rotated270
+                // Flipped: (s_w - (x+w), y, w, h)
+                // Rotated270 from Flipped:
+                // new_x = s_height_of_flipped_surface - (y_flipped + h_flipped)
+                //       = s_height - (y + h)
+                // new_y = x_flipped = s_w - (x+w)
+                new_x = s_height - (self.y + self.height);
+                new_y = s_width - (self.x + self.width);
+                new_width = self.height;
+                new_height = self.width;
+            }
+        }
+        Self::new(new_x, new_y, new_width, new_height)
+    }
+}
+
+const MAX_DAMAGE_RECTS: usize = 100; // Example limit
+
+#[derive(Debug, Clone)]
+pub struct DamageTracker {
+    pending_damage_buffer: Vec<Rectangle>,  // Damage in buffer coordinates
+    pending_damage_surface: Vec<Rectangle>, // Damage in surface-local coordinates (legacy)
+    current_damage: Vec<Rectangle>,         // Committed damage in surface-local coordinates, clipped to surface
+    damage_age: u32,                        // Counter for buffer age optimization
+}
+
+impl Default for DamageTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DamageTracker {
+    pub fn new() -> Self {
+        Self {
+            pending_damage_buffer: Vec::new(),
+            pending_damage_surface: Vec::new(),
+            current_damage: Vec::new(),
+            damage_age: 0,
+        }
+    }
+
+    // Helper to merge overlapping or adjacent rectangles
+    fn merge_rectangles(rects: &mut Vec<Rectangle>) {
+        if rects.len() <= 1 {
+            return;
+        }
+        let mut i = 0;
+        while i < rects.len() {
+            let mut j = i + 1;
+            let mut merged_current = false;
+            while j < rects.len() {
+                // A more robust check: if their union has the same area as sum of areas minus intersection area
+                // or simply, if union is not much larger than individual ones.
+                // For now, simple intersection or exact adjacency.
+                let r1 = rects[i];
+                let r2 = rects[j];
+                if r1.intersects(&r2) ||
+                   (r1.x == r2.x + r2.width && r1.y == r2.y && r1.height == r2.height && r1.width > 0 && r2.width > 0) || // r2 is left of r1
+                   (r1.x + r1.width == r2.x && r1.y == r2.y && r1.height == r2.height && r1.width > 0 && r2.width > 0) || // r2 is right of r1
+                   (r1.y == r2.y + r2.height && r1.x == r2.x && r1.width == r2.width && r1.height > 0 && r2.height > 0) || // r2 is above r1
+                   (r1.y + r1.height == r2.y && r1.x == r2.x && r1.width == r2.width && r1.height > 0 && r2.height > 0)    // r2 is below r1
+                {
+                    rects[i] = r1.union(&r2);
+                    rects.remove(j);
+                    merged_current = true;
+                    // No j increment here, as rects[j] is now a new rect
+                } else {
+                    j += 1;
+                }
+            }
+            if merged_current {
+                // Restart scan for rects[i] as it has changed and might merge with earlier rects if list was unsorted
+                // For simplicity assuming this pass is enough or list is somewhat sorted.
+                // To be fully robust, this merge might need multiple passes or a more complex algorithm.
+                // Or, simply restart i if a merge happened:
+                // i = 0; continue; // but this could be slow if many merges.
+                // Let's stick to one pass for now.
+            }
+            i += 1;
+        }
+    }
+
+    pub fn add_damage_buffer(&mut self, rect: Rectangle) {
+        if rect.is_empty() { return; }
+        self.pending_damage_buffer.push(rect);
+        //DamageTracker::merge_rectangles(&mut self.pending_damage_buffer); // Merge during commit_pending_damage
+        self.damage_age += 1;
+    }
+
+    pub fn add_damage_surface(&mut self, rect: Rectangle) {
+        if rect.is_empty() { return; }
+        self.pending_damage_surface.push(rect);
+        //DamageTracker::merge_rectangles(&mut self.pending_damage_surface); // Merge during commit_pending_damage
+        self.damage_age += 1;
+    }
+
+    fn transform_and_clip_damage_list(
+        damage_list: &mut Vec<Rectangle>,
+        attributes: &SurfaceAttributes,
+        is_buffer_damage: bool,
+        surface_boundary: &Rectangle,
+    ) {
+        let mut transformed_damage: Vec<Rectangle> = Vec::new();
+        let (buffer_width, buffer_height) = if let Some(buffer) = attributes.size /* This is wrong, needs actual buffer dimensions for transform */ {
+            // This 'size' in attributes is already scaled surface size.
+            // We need original buffer dimensions for correct transform origin.
+            // This part of the logic is tricky. For now, assume attributes.size IS the buffer dimension / scale.
+            // This assumption holds if surface size is always derived from buffer.
+            (attributes.size.0 as i32, attributes.size.1 as i32)
+        } else {
+            (0,0) // Should not happen if buffer is attached
+        };
+
+
+        for rect in damage_list.iter() {
+            if rect.is_empty() { continue; }
+
+            let transformed_rect = if is_buffer_damage {
+                if attributes.buffer_scale <= 0 { Rectangle::new(0,0,0,0) } else {
+                    // 1. Scale
+                    let scaled_rect = rect.scale(attributes.buffer_scale);
+                    // 2. Transform
+                    // The `s_width` and `s_height` for `rect.transform` should be the dimensions of the
+                    // surface in its "untransformed" state, i.e., after scaling but before wl_output_transform.
+                    // This is attributes.size.
+                    scaled_rect.transform(attributes.buffer_transform, surface_boundary.width, surface_boundary.height)
+                }
+            } else {
+                *rect // Already in surface coordinates
+            };
+
+            if !transformed_rect.is_empty() {
+                 let clipped_rect = transformed_rect.clipped_to(surface_boundary);
+                 if !clipped_rect.is_empty() {
+                    transformed_damage.push(clipped_rect);
+                 }
+            }
+        }
+        *damage_list = transformed_damage;
+    }
+
+
+    pub fn commit_pending_damage(&mut self, attributes: &SurfaceAttributes, new_buffer_committed: bool) {
+        let surface_boundary = Rectangle::new(0, 0, attributes.size.0 as i32, attributes.size.1 as i32);
+        if surface_boundary.is_empty() && !(self.pending_damage_buffer.is_empty() && self.pending_damage_surface.is_empty()) {
+            // If surface has no size, but damage is being committed, it usually means full damage to the future size.
+            // Or, it's an error state. For now, clear damage if surface is sizeless.
+            self.current_damage.clear();
+            self.pending_damage_buffer.clear();
+            self.pending_damage_surface.clear();
+            self.damage_age = 0;
+            return;
+        }
+
+
+        // Transform pending_damage_buffer to surface coordinates
+        DamageTracker::transform_and_clip_damage_list(&mut self.pending_damage_buffer, attributes, true, &surface_boundary);
+
+        // Clip pending_damage_surface (already in surface coordinates)
+        DamageTracker::transform_and_clip_damage_list(&mut self.pending_damage_surface, attributes, false, &surface_boundary);
+
+        // Combine damage
+        let mut combined_damage: Vec<Rectangle> = self.pending_damage_buffer.drain(..).collect();
+        combined_damage.extend(self.pending_damage_surface.drain(..));
+
+        // Merge all collected damage rectangles
+        DamageTracker::merge_rectangles(&mut combined_damage);
+
+        // Handle damage region overflow
+        let total_surface_area = surface_boundary.area();
+        let mut current_total_damage_area = 0;
+        for rect in &combined_damage {
+            current_total_damage_area += rect.area();
+        }
+
+        if combined_damage.len() > MAX_DAMAGE_RECTS ||
+           (total_surface_area > 0 && combined_damage.len() > 1 && current_total_damage_area as f32 / total_surface_area as f32 > 0.75) { // Avoid full damage if only one rect
+            self.current_damage = vec![surface_boundary];
+        } else {
+            self.current_damage = combined_damage;
+        }
+
+        if new_buffer_committed {
+            self.damage_age = 0;
+        }
+        // If no new buffer, damage_age continues from add_damage calls.
+    }
+
+    pub fn get_current_damage_clipped(&self, surface_size: (u32, u32)) -> Vec<Rectangle> {
+        let surface_boundary = Rectangle::new(0, 0, surface_size.0 as i32, surface_size.1 as i32);
+        if surface_boundary.is_empty() { return Vec::new(); }
+        self.current_damage.iter()
+            .map(|rect| rect.clipped_to(&surface_boundary))
+            .filter(|rect| !rect.is_empty())
+            .collect()
+    }
+
+    pub fn clear_all_damage(&mut self) {
+        self.pending_damage_buffer.clear();
+        self.pending_damage_surface.clear();
+        self.current_damage.clear();
+        self.damage_age = 0;
+    }
+}
+
+use crate::subcompositor::SubsurfaceState; // Import SubsurfaceState
+
+// Placeholder for SurfaceRole
+#[derive(Debug, Clone)] // Removed Copy, PartialEq, Eq as SubsurfaceState is not Copy/Eq by default
+pub enum SurfaceRole {
+    Toplevel, // Placeholder for actual Toplevel state struct
+    Subsurface(SubsurfaceState),
+    Cursor,   // Placeholder for actual Cursor state struct
+    DragIcon, // Placeholder for actual DragIcon state struct
+}
+
+// BufferObject is now replaced by Arc<Mutex<BufferDetails>> from novade-buffer-manager
+
+// Placeholder for WlCallback
+#[derive(Debug, Clone)]
+pub struct WlCallback {
+    // Placeholder, actual implementation will involve Wayland objects
+    pub id: u64,
+}
+
+// Placeholder for Region (similar to DamageTracker)
+#[derive(Debug, Clone, Default)]
+pub struct Region {
+    pub rectangles: Vec<Rectangle>,
+}
+
+impl Region {
+    pub fn new() -> Self {
+        Self { rectangles: Vec::new() }
+    }
+}
+
+pub struct Surface {
+    pub id: SurfaceId,
+    pub current_state: SurfaceState,
+    pub pending_attributes: SurfaceAttributes,
+    pub current_attributes: SurfaceAttributes,
+    pub damage_tracker: DamageTracker,
+    pub role: Option<SurfaceRole>,
+    // pub attached_buffer: Option<BufferObject>, // Replaced
+    pub pending_buffer: Option<Arc<Mutex<BufferDetails>>>,
+    pub current_buffer: Option<Arc<Mutex<BufferDetails>>>,
+    pub frame_callbacks: Vec<WlCallback>,
+    pub opaque_region: Option<Region>,
+    pub input_region: Option<Region>,
+
+    // Subsurface fields
+    pub children: Vec<SurfaceId>,   // List of direct child subsurfaces
+    pub parent: Option<SurfaceId>,  // If this surface is a subsurface
+
+    // Cache for synchronized subsurface state
+    // These are populated when a synchronized subsurface commits.
+    // They are applied when its parent commits (or when transitioning to desynchronized).
+    cached_pending_buffer: Option<Arc<Mutex<BufferDetails>>>,
+    cached_pending_attributes: Option<SurfaceAttributes>, // Using Option to clearly indicate if cache is populated
+    // Damage is trickier to cache directly if DamageTracker processes it immediately.
+    // For now, let's assume commit for sync subsurface populates these, and damage is part of attributes or handled separately.
+    // The DamageTracker itself has pending_damage_buffer/surface.
+    // When a sync subsurface commits, its pending damage is NOT yet moved to current_damage.
+    // It's processed when apply_cached_state_from_sync is called.
+}
+
+impl Surface {
+    pub fn new() -> Self { // ID is now generated internally
+        Self {
+            id: SurfaceId::new_unique(),
+            current_state: SurfaceState::Created,
+            pending_attributes: SurfaceAttributes::default(),
+            current_attributes: SurfaceAttributes::default(),
+            damage_tracker: DamageTracker::new(),
+            role: None,
+            // attached_buffer: None, // Replaced
+            pending_buffer: None,
+            current_buffer: None,
+            frame_callbacks: Vec::new(),
+            opaque_region: Some(Region::new()), // Wayland spec: initially the whole surface
+            input_region: Some(Region::new()),  // Wayland spec: initially the whole surface
+
+            children: Vec::new(),
+            parent: None,
+
+            cached_pending_buffer: None,
+            cached_pending_attributes: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum BufferAttachError {
+    BufferNotFound,
+    ClientMismatch, // If buffer is owned by a different client
+    InvalidBufferSize, // If buffer dimensions are zero or otherwise invalid
+    InvalidState, // If surface is in a state that doesn't allow attach (e.g., Destroyed)
+    InvalidBufferOffset, // Added here for attach validation consistency
+}
+
+#[derive(Debug)]
+pub enum CommitError {
+    InvalidState, // Surface is in a state that doesn't allow commit (e.g., Destroyed)
+    InvalidBufferSize, // e.g. zero dimension, or not divisible by scale
+    // InvalidBufferOffset is primarily an attach error, but commit might re-validate if needed.
+    // For now, primary validation in attach.
+}
+
+// WlCallback struct is defined above (near SurfaceRole)
+
+#[derive(Debug)]
+pub enum SurfaceTransitionError {
+    InvalidTransition,
+    // Add other error types as needed
+}
+
+impl Surface {
+    // Helper to release the current buffer, called on commit of new buffer or surface destruction
+    fn release_current_buffer(&mut self, buffer_manager: &mut BufferManager) {
+        if let Some(buffer_arc) = self.current_buffer.take() {
+            let buffer_id = buffer_arc.lock().unwrap().id;
+            buffer_manager.release_buffer(buffer_id);
+        }
+    }
+
+    // Helper to release a pending buffer if a new one is attached or surface is cleared/destroyed
+    fn release_pending_buffer(&mut self, buffer_manager: &mut BufferManager) {
+        if let Some(buffer_arc) = self.pending_buffer.take() {
+            let buffer_id = buffer_arc.lock().unwrap().id;
+            buffer_manager.release_buffer(buffer_id);
+        }
+    }
+
+    pub fn damage_buffer(&mut self, x: i32, y: i32, width: i32, height: i32) {
+        if self.current_state == SurfaceState::Destroyed { return; }
+        // Wayland spec: width and height must be positive.
+        // TODO: Consider sending a wl_surface protocol error if width/height are non-positive.
+        let rect = Rectangle::new(x, y, width, height);
+        if rect.is_empty() { return; }
+
+        let mut opt_buffer_dims: Option<(i32,i32)> = None;
+        if let Some(pending_ref) = &self.pending_buffer {
+             let details = pending_ref.lock().unwrap();
+             opt_buffer_dims = Some((details.width as i32, details.height as i32));
+        } else if let Some(current_ref) = &self.current_buffer {
+            let details = current_ref.lock().unwrap();
+            opt_buffer_dims = Some((details.width as i32, details.height as i32));
+        }
+
+        if let Some(buffer_dims) = opt_buffer_dims {
+            if buffer_dims.0 > 0 && buffer_dims.1 > 0 {
+                let buffer_bounds = Rectangle::new(0, 0, buffer_dims.0, buffer_dims.1);
+                let clipped_rect = rect.clipped_to(&buffer_bounds);
+                if !clipped_rect.is_empty() {
+                    self.damage_tracker.add_damage_buffer(clipped_rect);
+                }
+            }
+        }
+    }
+
+    pub fn damage_surface(&mut self, x: i32, y: i32, width: i32, height: i32) {
+        if self.current_state == SurfaceState::Destroyed { return; }
+        // Wayland spec: width and height must be positive.
+        // TODO: Consider sending a wl_surface protocol error if width/height are non-positive.
+        let rect = Rectangle::new(x, y, width, height);
+        if rect.is_empty() { return; }
+
+        let surface_bounds = Rectangle::new(0, 0, self.current_attributes.size.0 as i32, self.current_attributes.size.1 as i32);
+         if surface_bounds.is_empty() && (self.current_attributes.size.0 !=0 || self.current_attributes.size.1 !=0) {
+            return;
+        }
+        let clipped_rect = rect.clipped_to(&surface_bounds);
+        if !clipped_rect.is_empty() {
+            self.damage_tracker.add_damage_surface(clipped_rect);
+        }
+    }
+
+    pub fn attach_buffer(
+        &mut self,
+        buffer_manager: &mut BufferManager,
+        buffer_arc_opt: Option<Arc<Mutex<BufferDetails>>>,
+        client_id: ClientId,
+        x_offset: i32,
+        y_offset: i32,
+    ) -> Result<(), BufferAttachError> {
+        if self.current_state == SurfaceState::Destroyed {
+            return Err(BufferAttachError::InvalidState);
+        }
+        if x_offset != 0 || y_offset != 0 { // Assuming version >= 5
+            return Err(BufferAttachError::InvalidBufferOffset);
+        }
+        self.release_pending_buffer(buffer_manager);
+        self.pending_buffer = None;
+        if let Some(buffer_arc) = buffer_arc_opt {
+            {
+                let buffer_details = buffer_arc.lock().unwrap();
+                if let Some(owner_id) = buffer_details.client_owner_id {
+                    if owner_id != client_id { return Err(BufferAttachError::ClientMismatch); }
+                }
+                if buffer_details.width == 0 || buffer_details.height == 0 {
+                    return Err(BufferAttachError::InvalidBufferSize);
+                }
+            }
+            buffer_arc.lock().unwrap().increment_ref_count();
+            self.pending_buffer = Some(buffer_arc.clone());
+            let (buffer_width, buffer_height) = {
+                let details = buffer_arc.lock().unwrap();
+                (details.width, details.height)
+            };
+            self.pending_attributes.size = (buffer_width, buffer_height);
+        } else {
+            self.pending_buffer = None;
+        }
+        self.pending_attributes.buffer_offset = (x_offset, y_offset);
+        if self.current_state != SurfaceState::PendingBuffer {
+            let _ = self.transition_to(SurfaceState::PendingBuffer);
+        }
+        Ok(())
+    }
+
+    pub fn commit(&mut self, buffer_manager: &mut BufferManager) -> Result<(), CommitError> {
+        if self.current_state == SurfaceState::Destroyed {
+            return Err(CommitError::InvalidState);
+        }
+        if !matches!(self.current_state, SurfaceState::Created | SurfaceState::PendingBuffer | SurfaceState::Committed) {
+            return Err(CommitError::InvalidState);
+        }
+
+        // --- Validation Phase ---
+        if let Some(pending_buffer_arc) = &self.pending_buffer {
+            let pending_buffer_details = pending_buffer_arc.lock().unwrap();
+            if pending_buffer_details.width == 0 || pending_buffer_details.height == 0 {
+                return Err(CommitError::InvalidBufferSize);
+            }
+            let scale = self.pending_attributes.buffer_scale;
+            if scale <= 0 {
+                return Err(CommitError::InvalidBufferSize);
+            }
+            if pending_buffer_details.width % (scale as u32) != 0 ||
+               pending_buffer_details.height % (scale as u32) != 0 {
+                return Err(CommitError::InvalidBufferSize);
+            }
+        }
+
+        // --- Synchronized Subsurface Handling ---
+        let mut is_currently_synchronized_subsurface = false;
+        if let Some(SurfaceRole::Subsurface(ref mut subsurface_state)) = self.role {
+            if subsurface_state.sync_mode == SubsurfaceSyncMode::Synchronized {
+                is_currently_synchronized_subsurface = true;
+                subsurface_state.needs_apply_on_parent_commit = true;
+
+                if let Some(pending_buffer_arc_real) = &self.pending_buffer {
+                    pending_buffer_arc_real.lock().unwrap().increment_ref_count();
+                    self.cached_pending_buffer = Some(pending_buffer_arc_real.clone());
+                } else {
+                    self.cached_pending_buffer = None;
+                }
+                self.cached_pending_attributes = Some(self.pending_attributes);
+                self.pending_buffer.take();
+
+                let _ = self.transition_to(SurfaceState::Committed);
+                return Ok(());
+            }
+        }
+
+        // --- Regular Commit Logic (for Toplevels or Desynchronized Subsurfaces) ---
+        let mut new_content_committed = false;
+        if self.current_state == SurfaceState::PendingBuffer {
+            new_content_committed = true;
+        }
+
+        self.current_attributes = self.pending_attributes;
+
+        if new_content_committed {
+            self.release_current_buffer(buffer_manager);
+            self.current_buffer = self.pending_buffer.take();
+        }
+
+        let mut applied_cache_for_desync = false;
+        if !is_currently_synchronized_subsurface {
+            if let Some(SurfaceRole::Subsurface(ref mut subsurface_state)) = self.role {
+                 if subsurface_state.sync_mode == SubsurfaceSyncMode::Desynchronized &&
+                    subsurface_state.needs_apply_on_parent_commit {
+                     self.apply_cached_state_from_sync(buffer_manager)?;
+                     applied_cache_for_desync = true;
+                 }
+            }
+        }
+
+        if !applied_cache_for_desync {
+            self.damage_tracker.commit_pending_damage(&self.current_attributes, new_content_committed);
+        }
+
+        let _ = self.transition_to(SurfaceState::Committed);
+        Ok(())
+    }
+
+    pub fn apply_cached_state_from_sync(&mut self, buffer_manager: &mut BufferManager) -> Result<(), CommitError> {
+        if self.current_state == SurfaceState::Destroyed {
+            return Err(CommitError::InvalidState);
+        }
+
+        let mut needs_apply_flag_was_set = false;
+        if let Some(SurfaceRole::Subsurface(ref mut subsurface_state)) = self.role {
+            if subsurface_state.needs_apply_on_parent_commit {
+                needs_apply_flag_was_set = true;
+                subsurface_state.needs_apply_on_parent_commit = false;
+            } else {
+                return Ok(());
+            }
+        } else {
+            return Err(CommitError::InvalidState);
+        }
+
+        if !needs_apply_flag_was_set {
+            return Ok(());
+        }
+
+        if let Some(cached_attrs) = self.cached_pending_attributes.take() {
+            self.current_attributes = cached_attrs;
+        }
+
+        self.release_current_buffer(buffer_manager);
+        self.current_buffer = self.cached_pending_buffer.take();
+
+        let new_content_was_cached = self.cached_pending_attributes.is_some();
+
+        self.damage_tracker.commit_pending_damage(&self.current_attributes, new_content_was_cached);
+        Ok(())
+    }
+
+    pub fn prepare_for_destruction(
+        &mut self,
+        buffer_manager: &mut BufferManager,
+        surface_registry_accessor: &impl surface_registry::SurfaceRegistryAccessor,
+    ) {
+        if let Some(buffer_arc) = self.pending_buffer.take() {
+            buffer_manager.release_buffer(buffer_arc.lock().unwrap().id);
+        }
+        if let Some(buffer_arc) = self.current_buffer.take() {
+            buffer_manager.release_buffer(buffer_arc.lock().unwrap().id);
+        }
+        if let Some(cached_buffer_arc) = self.cached_pending_buffer.take() {
+             buffer_manager.release_buffer(cached_buffer_arc.lock().unwrap().id);
+        }
+
+
+        if let Some(parent_id) = self.parent.take() {
+            if let Some(parent_surface_arc) = surface_registry_accessor.get_surface(parent_id) {
+                if let Ok(mut parent_surface) = parent_surface_arc.lock() {
+                    parent_surface.children.retain(|child_id| *child_id != self.id);
+                }
+            }
+        }
+
+        let children_to_unmap = std::mem::take(&mut self.children);
+        for child_id in children_to_unmap {
+            if let Some(child_surface_arc) = surface_registry_accessor.get_surface(child_id) {
+                if let Ok(mut child_surface) = child_surface_arc.lock() {
+                    if let Some(SurfaceRole::Subsurface(ref mut sub_state)) = child_surface.role {
+                        // Mark as orphaned: parent_id could be set to a sentinel, or role cleared.
+                        // For now, just clearing parent link. The child is now effectively unmapped.
+                        child_surface.parent = None;
+                        sub_state.parent_id = SurfaceId::new_unique(); // Or some other invalid ID
+                                                                       // To prevent it from thinking it's still attached.
+                        // Actual recursive destruction/unregistration will be handled by the main loop
+                        // in SurfaceRegistry::unregister_surface.
+                    }
+                }
+            }
+        }
+
+        self.frame_callbacks.clear();
+        self.damage_tracker.clear_all_damage();
+        self.current_state = SurfaceState::Destroyed;
+    }
+
+
+    pub fn frame(&mut self, callback_id: u64) {
+
+pub mod surface_registry {
+    use super::{Surface, SurfaceId, SurfaceState, SurfaceRole};
+    use crate::buffer_manager::BufferManager; // Needed for unregister_surface
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    /// Trait for accessing surfaces from the registry, used to decouple
+    /// `Surface::prepare_for_destruction` from needing a direct `&mut SurfaceRegistry`,
+    /// which can cause borrowing issues if `SurfaceRegistry::unregister_surface` calls it.
+    pub trait SurfaceRegistryAccessor {
+        fn get_surface(&self, id: SurfaceId) -> Option<Arc<Mutex<Surface>>>;
+        // fn unregister_child_from_map(&mut self, id: SurfaceId) -> Option<Arc<Mutex<Surface>>>;
+    }
+
+    #[derive(Default)]
+    pub struct SurfaceRegistry {
+        surfaces: HashMap<SurfaceId, Arc<Mutex<Surface>>>,
+    }
+
+    impl SurfaceRegistryAccessor for SurfaceRegistry {
+        fn get_surface(&self, id: SurfaceId) -> Option<Arc<Mutex<Surface>>> {
+            self.surfaces.get(&id).cloned()
+        }
+    }
+
+    impl SurfaceRegistry {
+        pub fn new() -> Self {
+            Self {
+                surfaces: HashMap::new(),
+            }
+        }
+
+        pub fn register_new_surface(&mut self) -> (SurfaceId, Arc<Mutex<Surface>>) {
+            // Note on no_memory for Surface allocation:
+            // Rust's direct allocation (like Arc::new(Mutex::new(surface))) panics on OOM.
+            // A robust Wayland compositor would use fallible allocation (e.g., Box::try_new)
+            // and if it fails, propagate the error upwards to ultimately send wl_display.error
+            // with the `no_memory` code to the client.
+            let surface = Surface::new();
+            let id = surface.id;
+            let arc_surface = Arc::new(Mutex::new(surface));
+            self.surfaces.insert(id, arc_surface.clone());
+            (id, arc_surface)
+        }
+
+        pub fn register_surface_arc(&mut self, surface_arc: Arc<Mutex<Surface>>) -> SurfaceId {
+            let id = surface_arc.lock().unwrap().id;
+            self.surfaces.insert(id, surface_arc);
+            id
+        }
+
+        pub fn get_surface(&self, id: SurfaceId) -> Option<Arc<Mutex<Surface>>> {
+            self.surfaces.get(&id).cloned()
+        }
+
+        pub fn unregister_surface(
+            &mut self,
+            surface_id: SurfaceId,
+            buffer_manager: &mut BufferManager,
+        ) -> Option<Arc<Mutex<Surface>>> {
+            if let Some(surface_arc) = self.surfaces.get(&surface_id).cloned() {
+                // Collect children IDs before locking the current surface for destruction.
+                let children_ids: Vec<SurfaceId> = { // Explicit scope for lock
+                    let surface_guard = surface_arc.lock().unwrap();
+                    surface_guard.children.clone()
+                };
+
+                // Call prepare_for_destruction on the current surface.
+                // This will release its buffers, disassociate from its parent,
+                // and update its children's parent links.
+                { // Explicit scope for lock
+                    let mut surface_guard = surface_arc.lock().unwrap();
+                    if surface_guard.current_state != SurfaceState::Destroyed {
+                        surface_guard.prepare_for_destruction(buffer_manager, self);
+                    }
+                }
+
+                // Now, recursively unregister all children identified before destruction.
+                // This ensures that `prepare_for_destruction` for each child is called,
+                // which handles buffer releases and further parent/child list modifications.
+                for child_id in children_ids {
+                    self.unregister_surface(child_id, buffer_manager);
+                }
+
+                // Finally, remove the target surface from the registry.
+                self.surfaces.remove(&surface_id)
+            } else {
+                None // Surface not found
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces the comprehensive Surface Management Module for the NovaDE Wayland compositor. This module is responsible for handling the lifecycle, state, buffer attachments, damage tracking, and hierarchical organization of Wayland surfaces.

Key features implemented:

1.  **Surface Object Creation**:
    *   `Surface` struct with unique `SurfaceId`, managing current and
        pending attributes (position, size, transform, alpha, buffer scale/transform).
    *   `SurfaceState` machine (`Created`, `PendingBuffer`, `Committed`,
        `Destroyed`, etc.) to govern lifecycle.
    *   `SurfaceRegistry` for global, thread-safe management of surfaces.

2.  **Buffer Attachment Handling**:
    *   Introduced `novade-buffer-manager` crate with `BufferManager`
        for tracking `BufferDetails` (ID, type, format, dimensions, owner).
    *   Implemented reference counting for shared buffers.
    *   `Surface::attach_buffer()` handles validation (client ownership,
        size, offset as per wl_surface v5+) and associates buffers with
        surfaces.
    *   `Surface::commit()` correctly transitions pending buffers to current,
        managing reference counts and simulating `wl_buffer.release`.

3.  **Damage Region Calculation**:
    *   `DamageTracker` for accumulating damage from `wl_surface.damage`
        (surface coordinates) and `wl_surface.damage_buffer` (buffer
        coordinates).
    *   Transformation of buffer damage to surface coordinates considering
        buffer scale and transform during commit.
    *   Clipping of damage regions against surface boundaries.
    *   Basic merging of overlapping/adjacent damage rectangles.
    *   Graceful fallback to full-surface damage on overflow.
    *   `damage_age` tracking for buffer age optimizations.

4.  **Surface State Commit**:
    *   Atomic application of pending state (attributes, buffer, damage)
        to current state within `Surface::commit()`.
    *   Validation of state consistency (e.g., buffer dimensions vs.
        scale) before commit.
    *   Mechanism for registering and retrieving `wl_surface.frame`
        callbacks (`Surface::frame()`, `Surface::take_frame_callbacks()`).

5.  **Subsurface Hierarchy Management**:
    *   Introduced `novade-compositor-core::subcompositor` module.
    *   `SurfaceRole::Subsurface` with `SubsurfaceState` (parent, position,
        sync mode).
    *   Parent-child relationships tracked in `Surface` (parent, children).
    *   Logic for `wl_subcompositor.get_subsurface` and `wl_subsurface`
        requests (`set_position`, `place_above`, `place_below`, `set_sync`,
        `set_desync`).
    *   Distinct commit behavior for synchronized (cached state applied by
        parent commit) and desynchronized subsurfaces.

6.  **Error Handling and Resource Cleanup**:
    *   Comprehensive error types (`BufferAttachError`, `CommitError`,
        `SubsurfaceError`).
    *   Robust surface destruction (`SurfaceRegistry::unregister_surface` and
        `Surface::prepare_for_destruction`):
        *   Releases buffers via `BufferManager`.
        *   Correctly severs parent-child links.
        *   Recursively unregisters/unmaps child subsurfaces.
    *   Cycle detection for subsurface hierarchies in `get_subsurface`.
    *   Comments added for future Wayland-specific error reporting.

7.  **Testing**:
    *   Extensive unit tests for `BufferManager`, `SurfaceRegistry`,
        `Surface` operations (lifecycle, attach, commit, damage), and
        `Subsurface` logic (creation, roles, cycles, stacking, sync modes).

8.  **Documentation**:
    *   Added Rustdoc comments to public APIs in `novade-buffer-manager`
        and `novade-compositor-core` crates.

This module forms a critical part of the NovaDE compositor, adhering to Wayland protocol specifications and designed for robustness and future extensibility.