### PR TITLE
feat: Implement initial window_mechanics module

### DIFF
--- a/novade-system/src/lib.rs
+++ b/novade-system/src/lib.rs
@@ -10,6 +10,7 @@ pub mod filesystem_service; // Added for assistant integration
 pub mod system_services;
 pub mod system_settings_service; // Added for assistant integration
 pub mod window_info_provider;
+pub mod window_mechanics;
 pub use application_manager::{ApplicationManager, AppInfo}; // Added for assistant integration
 pub use filesystem_service::{FileSystemService, FileInfo, UserContext}; // Added for assistant integration
 pub use system_settings_service::{SystemSettingsService, SystemSettingInfo}; // Added for assistant integration

--- a/novade-system/src/window_mechanics/data_types.rs
+++ b/novade-system/src/window_mechanics/data_types.rs
@@ -1,0 +1,287 @@
+// novade-system/src/window_mechanics/data_types.rs
+
+use novade_core::types::geometry::{Point, Size};
+use uuid::Uuid;
+
+/// Unique identifier for a window.
+///
+/// Wraps a `uuid::Uuid` to provide strong typing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct WindowId(Uuid);
+
+impl WindowId {
+    /// Creates a new, unique `WindowId`.
+    pub fn new_v4() -> Self {
+        WindowId(Uuid::new_v4())
+    }
+}
+
+impl Default for WindowId {
+    fn default() -> Self {
+        Self::new_v4()
+    }
+}
+
+impl std::fmt::Display for WindowId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Represents the geometry of a window using floating-point coordinates and dimensions.
+///
+/// This uses `Point<f64>` for origin and `Size<f64>` for dimensions from `novade_core`.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct WindowRect {
+    /// The top-left corner of the window.
+    pub origin: Point<f64>,
+    /// The width and height of the window.
+    pub size: Size<f64>,
+}
+
+impl WindowRect {
+    /// Creates a new `WindowRect`.
+    pub fn new(x: f64, y: f64, width: f64, height: f64) -> Self {
+        WindowRect {
+            origin: Point::new(x, y),
+            size: Size::new(width, height),
+        }
+    }
+}
+
+/// Represents the various states a window can be in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WindowState {
+    /// The window is managed by a tiling algorithm.
+    Tiled,
+    /// The window is floating freely, not managed by tiling.
+    Floating,
+    /// The window is minimized (not visible).
+    Minimized,
+    /// The window is maximized to fill the workspace.
+    Maximized,
+    /// The window is in fullscreen mode.
+    Fullscreen,
+}
+
+impl Default for WindowState {
+    fn default() -> Self {
+        WindowState::Tiled
+    }
+}
+
+/// Contains information about a specific window.
+///
+/// This structure holds metadata like the window's ID, title, geometry,
+/// and its current state (e.g., tiled, floating).
+#[derive(Debug, Clone, PartialEq)]
+pub struct WindowInfo {
+    /// Unique identifier for this window.
+    pub id: WindowId,
+    /// The title of the window.
+    pub title: String,
+    /// The current geometry (position and size) of the window.
+    pub rect: WindowRect,
+    /// The current state of the window (e.g., Tiled, Floating).
+    pub state: WindowState,
+    // pub xdg_surface_handle: Option<SmithayXdgSurfaceHandleType>, // To be added later
+}
+
+impl WindowInfo {
+    /// Creates a new `WindowInfo`.
+    pub fn new(id: WindowId, title: String, rect: WindowRect, state: WindowState) -> Self {
+        WindowInfo { id, title, rect, state }
+    }
+}
+
+/// Unique identifier for a workspace.
+///
+/// Wraps a `uuid::Uuid` for type safety.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct WorkspaceId(Uuid);
+
+impl WorkspaceId {
+    /// Creates a new, unique `WorkspaceId`.
+    pub fn new_v4() -> Self {
+        WorkspaceId(Uuid::new_v4())
+    }
+}
+
+impl Default for WorkspaceId {
+    fn default() -> Self {
+        Self::new_v4()
+    }
+}
+
+impl std::fmt::Display for WorkspaceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Represents the available tiling layout algorithms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TilingLayout {
+    /// A layout that typically has a main "master" area and a stacking area.
+    Tall,
+    /// A layout that arranges windows in a grid.
+    Grid,
+    /// A layout that arranges windows in a Fibonacci spiral (placeholder).
+    Fibonacci,
+    // Floating is handled by WindowState::Floating, not as a layout itself here.
+}
+
+impl Default for TilingLayout {
+    fn default() -> Self {
+        TilingLayout::Tall
+    }
+}
+
+/// Contains information about a workspace.
+///
+/// This includes its ID, a human-readable name, the list of windows it contains,
+/// and the current tiling layout algorithm being applied.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WorkspaceInfo {
+    /// Unique identifier for this workspace.
+    pub id: WorkspaceId,
+    /// A human-readable name for the workspace (e.g., "Workspace 1", "Web").
+    pub name: String,
+    /// A list of `WindowId`s representing the windows present in this workspace.
+    /// The order might be significant depending on the layout algorithm.
+    pub windows: Vec<WindowId>,
+    /// The current tiling layout algorithm active for this workspace.
+    pub current_layout: TilingLayout,
+    // pub screen_id: Option<ScreenId>, // If workspaces are tied to specific screens
+}
+
+impl WorkspaceInfo {
+    /// Creates a new `WorkspaceInfo`.
+    pub fn new(id: WorkspaceId, name: String, current_layout: TilingLayout) -> Self {
+        WorkspaceInfo {
+            id,
+            name,
+            windows: Vec::new(),
+            current_layout,
+        }
+    }
+}
+
+/// Contains information about a connected display screen.
+///
+/// This primarily includes its resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct ScreenInfo {
+    /// The width of the screen in pixels (or logical units if scaled).
+    pub width: f64,
+    /// The height of the screen in pixels (or logical units if scaled).
+    pub height: f64,
+    // pub id: ScreenId, // A unique identifier for the screen/output
+    // pub workspaces: Vec<WorkspaceId>, // Workspaces currently displayed on this screen
+}
+
+impl ScreenInfo {
+    /// Creates a new `ScreenInfo`.
+    pub fn new(width: f64, height: f64) -> Self {
+        ScreenInfo { width, height }
+    }
+}
+
+
+// Unit tests for data types
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use novade_core::types::geometry::{Point, Size}; // For direct use in tests
+
+    #[test]
+    fn window_id_creation_and_default() {
+        let id1 = WindowId::new_v4();
+        let id2 = WindowId::new_v4();
+        let default_id = WindowId::default();
+        assert_ne!(id1, id2);
+        assert_ne!(id1, default_id);
+        assert_ne!(id2, default_id); // Ensure default also generates a new one
+        println!("Window ID 1: {}", id1); // For manual inspection if needed
+        println!("Window ID 2: {}", id2);
+    }
+
+    #[test]
+    fn window_rect_creation() {
+        let rect = WindowRect::new(10.0, 20.0, 300.0, 200.0);
+        assert_eq!(rect.origin.x, 10.0);
+        assert_eq!(rect.origin.y, 20.0);
+        assert_eq!(rect.size.width, 300.0);
+        assert_eq!(rect.size.height, 200.0);
+
+        let default_rect = WindowRect::default();
+        assert_eq!(default_rect.origin.x, 0.0);
+        assert_eq!(default_rect.origin.y, 0.0);
+        assert_eq!(default_rect.size.width, 0.0);
+        assert_eq!(default_rect.size.height, 0.0);
+    }
+
+    #[test]
+    fn window_state_default() {
+        assert_eq!(WindowState::default(), WindowState::Tiled);
+    }
+
+    #[test]
+    fn window_info_creation() {
+        let id = WindowId::new_v4();
+        let rect = WindowRect::new(0.0, 0.0, 800.0, 600.0);
+        let info = WindowInfo::new(id, "Test Window".to_string(), rect, WindowState::Floating);
+        assert_eq!(info.id, id);
+        assert_eq!(info.title, "Test Window");
+        assert_eq!(info.rect, rect);
+        assert_eq!(info.state, WindowState::Floating);
+    }
+
+    #[test]
+    fn workspace_id_creation_and_default() {
+        let id1 = WorkspaceId::new_v4();
+        let id2 = WorkspaceId::new_v4();
+        let default_id = WorkspaceId::default();
+        assert_ne!(id1, id2);
+        assert_ne!(id1, default_id);
+        assert_ne!(id2, default_id);
+        println!("Workspace ID 1: {}", id1);
+        println!("Workspace ID 2: {}", id2);
+    }
+
+    #[test]
+    fn tiling_layout_default() {
+        assert_eq!(TilingLayout::default(), TilingLayout::Tall);
+    }
+
+    #[test]
+    fn workspace_info_creation() {
+        let id = WorkspaceId::new_v4();
+        let info = WorkspaceInfo::new(id, "Primary".to_string(), TilingLayout::Grid);
+        assert_eq!(info.id, id);
+        assert_eq!(info.name, "Primary");
+        assert!(info.windows.is_empty());
+        assert_eq!(info.current_layout, TilingLayout::Grid);
+    }
+
+    #[test]
+    fn workspace_info_add_window() {
+        let id = WorkspaceId::new_v4();
+        let mut info = WorkspaceInfo::new(id, "Primary".to_string(), TilingLayout::Grid);
+        let window_id = WindowId::new_v4();
+        info.windows.push(window_id);
+        assert_eq!(info.windows.len(), 1);
+        assert_eq!(info.windows[0], window_id);
+    }
+
+    #[test]
+    fn screen_info_creation() {
+        let screen = ScreenInfo::new(1920.0, 1080.0);
+        assert_eq!(screen.width, 1920.0);
+        assert_eq!(screen.height, 1080.0);
+
+        let default_screen = ScreenInfo::default();
+        assert_eq!(default_screen.width, 0.0);
+        assert_eq!(default_screen.height, 0.0);
+    }
+}

--- a/novade-system/src/window_mechanics/error.rs
+++ b/novade-system/src/window_mechanics/error.rs
@@ -1,0 +1,145 @@
+// novade-system/src/window_mechanics/error.rs
+
+use thiserror::Error;
+// Import standard I/O error, as it was mentioned as an example in the spec,
+// though it might not be used immediately.
+use std::io;
+
+/// Defines specific errors that can occur within the window management system.
+///
+/// These errors are used to provide context about failures in operations like
+/// layout calculations, window identification, or interactions with the
+/// underlying compositor state.
+#[derive(Error, Debug)]
+pub enum WindowManagerError {
+    /// Occurs when an operation is attempted with an invalid or unknown window ID.
+    ///
+    /// Contains the problematic window ID.
+    #[error("Invalid window ID: {0}")]
+    InvalidWindowId(String),
+
+    /// Occurs when a window layout calculation fails.
+    ///
+    /// Contains a message describing the reason for the layout failure.
+    #[error("Failed to calculate window layout: {0}")]
+    LayoutCalculation(String),
+
+    /// Occurs when there's an issue accessing or manipulating the compositor's state.
+    ///
+    /// This could be due to locking issues, unexpected state, or other
+    /// problems related to the underlying `smithay` compositor integration.
+    /// Contains a message describing the access error.
+    #[error("Failed to access compositor state: {0}")]
+    CompositorStateAccess(String),
+
+    /// Occurs when an unsupported or currently unimplemented window operation is requested.
+    ///
+    /// Contains a message describing the unsupported operation.
+    #[error("Unsupported window operation: {0}")]
+    UnsupportedOperation(String),
+
+    /// Placeholder for I/O errors, if any operations directly cause them.
+    /// For example, if window configurations were read from/written to files.
+    #[error("I/O error: {0}")]
+    IoError(#[from] io::Error),
+
+    /// A generic error type for other, less specific window management issues.
+    ///
+    /// Contains a general message describing the error.
+    #[error("Generic window manager error: {0}")]
+    Other(String),
+}
+
+// It can be useful to implement `From` for common error types that might
+// be encountered and need to be converted into `WindowManagerError`.
+// For instance, if a function returns `Result<_, SomeOtherError>`, you might
+// want to convert `SomeOtherError` into `WindowManagerError::Other` or a more
+// specific variant.
+
+// Example: Implementing From for a hypothetical external error type
+// (This is commented out as no specific external errors are defined yet beyond std::io::Error)
+/*
+#[derive(Error, Debug)]
+pub enum ExternalError {
+    #[error("An external problem occurred: {0}")]
+    Problem(String),
+}
+
+impl From<ExternalError> for WindowManagerError {
+    fn from(err: ExternalError) -> Self {
+        WindowManagerError::Other(format!("External error: {}", err))
+    }
+}
+*/
+
+// Unit tests for the error enum
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error; // Required for source() and Display assertions
+
+    #[test]
+    fn invalid_window_id_formats_correctly() {
+        let error = WindowManagerError::InvalidWindowId("test-id-123".to_string());
+        assert_eq!(format!("{}", error), "Invalid window ID: test-id-123");
+    }
+
+    #[test]
+    fn layout_calculation_formats_correctly() {
+        let error = WindowManagerError::LayoutCalculation("Algorithm failure".to_string());
+        assert_eq!(format!("{}", error), "Failed to calculate window layout: Algorithm failure");
+    }
+
+    #[test]
+    fn compositor_state_access_formats_correctly() {
+        let error = WindowManagerError::CompositorStateAccess("Failed to acquire lock".to_string());
+        assert_eq!(format!("{}", error), "Failed to access compositor state: Failed to acquire lock");
+    }
+
+    #[test]
+    fn unsupported_operation_formats_correctly() {
+        let error = WindowManagerError::UnsupportedOperation("Minimize not implemented".to_string());
+        assert_eq!(format!("{}", error), "Unsupported window operation: Minimize not implemented");
+    }
+
+    #[test]
+    fn io_error_formats_correctly() {
+        let original_io_error = io::Error::new(io::ErrorKind::NotFound, "File not found");
+        // Store the Display output of original_io_error BEFORE it's moved into WindowManagerError
+        let original_io_error_str = format!("{}", original_io_error);
+
+        let error = WindowManagerError::IoError(original_io_error);
+        // The format of an io::Error is platform-dependent and may vary.
+        // We check if the Display output of WindowManagerError::IoError contains the original error's string.
+        // This is a common way to test this kind of wrapping.
+        assert!(format!("{}", error).contains(&original_io_error_str));
+        assert!(format!("{}", error).starts_with("I/O error:"));
+
+        // Additionally, check the source
+        match error.source() {
+            Some(source_err) => {
+                // Check if the source error is indeed an io::Error
+                assert!(source_err.is::<io::Error>());
+                // And that its description matches (or is contained within) the original
+                 assert!(source_err.to_string().contains("File not found"));
+            }
+            None => panic!("Source error not found for IoError variant"),
+        }
+    }
+
+    #[test]
+    fn other_error_formats_correctly() {
+        let error = WindowManagerError::Other("A miscellaneous error occurred".to_string());
+        assert_eq!(format!("{}", error), "Generic window manager error: A miscellaneous error occurred");
+    }
+
+    // Example of testing `From` implementation if one were active
+    /*
+    #[test]
+    fn from_external_error() {
+        let external_err = ExternalError::Problem("dependency failed".to_string());
+        let wm_error = WindowManagerError::from(external_err);
+        assert_eq!(format!("{}", wm_error), "Generic window manager error: External error: An external problem occurred: dependency failed");
+    }
+    */
+}

--- a/novade-system/src/window_mechanics/manager.rs
+++ b/novade-system/src/window_mechanics/manager.rs
@@ -1,0 +1,697 @@
+// novade-system/src/window_mechanics/manager.rs
+
+use std::collections::HashMap;
+use tracing::{info, debug, error, warn};
+
+// Import our own error and data types
+use super::error::WindowManagerError;
+use super::data_types::{
+    WindowId, WindowInfo, WindowRect, WindowState,
+    WorkspaceId, WorkspaceInfo, TilingLayout, ScreenInfo,
+};
+use novade_core::types::geometry::{Point, Size};
+
+/// Manages the arrangement, sizing, and state of windows and workspaces.
+///
+/// The `WindowManager` is responsible for applying tiling algorithms, handling
+/// window focus, managing workspaces, and reacting to window events (like creation
+/// or closure). It will eventually interact with the Smithay compositor state
+/// to apply these changes to the actual Wayland surfaces.
+#[derive(Debug)]
+pub struct WindowManager {
+    /// A map of all known windows, keyed by their `WindowId`.
+    windows: HashMap<WindowId, WindowInfo>,
+    /// A map of all workspaces, keyed by their `WorkspaceId`.
+    workspaces: HashMap<WorkspaceId, WorkspaceInfo>,
+    /// The ID of the currently active workspace.
+    active_workspace_id: WorkspaceId,
+    // /// Shared access to the global compositor state.
+    // /// This will be needed for interacting with Smithay surfaces.
+    // /// Example type: smithay_compositor_state: Arc<RwLock<CompositorState>>,
+}
+
+impl WindowManager {
+    /// Creates a new `WindowManager`.
+    ///
+    /// Initializes with a default workspace. In a real scenario, this might
+    /// take configuration for screen setups or access to the compositor state.
+    pub fn new() -> Result<Self, WindowManagerError> {
+        info!("Initializing WindowManager.");
+
+        let mut workspaces = HashMap::new();
+        let default_workspace_id = WorkspaceId::new_v4();
+        let default_workspace_name = "Workspace 1".to_string();
+        let default_layout = TilingLayout::Tall;
+
+        let default_workspace = WorkspaceInfo::new(
+            default_workspace_id,
+            default_workspace_name.clone(),
+            default_layout,
+        );
+        workspaces.insert(default_workspace_id, default_workspace);
+
+        debug!(
+            "Default workspace created: ID={}, Name='{}', Layout={:?}",
+            default_workspace_id, default_workspace_name, default_layout
+        );
+
+        Ok(WindowManager {
+            windows: HashMap::new(),
+            workspaces,
+            active_workspace_id: default_workspace_id,
+        })
+    }
+
+    /// Handles the registration of a new window.
+    ///
+    /// A new `WindowInfo` is created and associated with a generated `WindowId`.
+    /// The window is added to the currently active workspace, and the layout
+    /// for that workspace is recalculated.
+    ///
+    /// # Arguments
+    /// * `surface_title`: The title of the new window.
+    ///
+    /// # Returns
+    /// A `Result` containing the `WindowId` of the newly created window, or
+    /// a `WindowManagerError`.
+    pub fn on_new_window(&mut self, surface_title: String) -> Result<WindowId, WindowManagerError> {
+        let window_id = WindowId::new_v4();
+        let initial_rect = WindowRect::default();
+        let initial_state = WindowState::Tiled;
+
+        let window_info = WindowInfo::new(
+            window_id,
+            surface_title.clone(),
+            initial_rect,
+            initial_state,
+        );
+
+        self.windows.insert(window_id, window_info);
+        debug!("Registered new window: ID={}, Title='{}'", window_id, surface_title);
+
+        let active_workspace = self.workspaces.get_mut(&self.active_workspace_id)
+            .ok_or_else(|| {
+                error!("Active workspace ID {} not found during new window creation.", self.active_workspace_id);
+                WindowManagerError::Other(format!("Active workspace {} not found", self.active_workspace_id))
+            })?;
+
+        active_workspace.windows.push(window_id);
+        info!("Added window {} to workspace {}", window_id, active_workspace.id);
+
+        self.recalculate_layout(self.active_workspace_id)?;
+
+        Ok(window_id)
+    }
+
+    /// Handles the closure of an existing window.
+    ///
+    /// The window is removed from the manager's list and from any workspace
+    /// it belonged to. The layout for affected workspaces is then recalculated.
+    ///
+    /// # Arguments
+    /// * `window_id`: The ID of the window to be closed.
+    ///
+    /// # Returns
+    /// A `Result` indicating success, or an `InvalidWindowId` error or `Other` error.
+    pub fn on_window_closed(&mut self, window_id: &WindowId) -> Result<(), WindowManagerError> {
+        if self.windows.remove(window_id).is_none() {
+            warn!("Attempted to close non-existent window: {}", window_id);
+            return Err(WindowManagerError::InvalidWindowId(window_id.to_string()));
+        }
+        info!("Window {} closed and removed from manager.", window_id);
+
+        let mut affected_workspaces = Vec::new();
+        for (id, workspace_info) in self.workspaces.iter_mut() {
+            if workspace_info.windows.contains(window_id) {
+                workspace_info.windows.retain(|id_in_list| id_in_list != window_id);
+                debug!("Removed window {} from workspace {}", window_id, id);
+                affected_workspaces.push(*id);
+            }
+        }
+
+        for ws_id in affected_workspaces {
+            self.recalculate_layout(ws_id)?;
+        }
+        Ok(())
+    }
+
+    /// Recalculates and applies the layout for a given workspace.
+    ///
+    /// # Arguments
+    /// * `workspace_id`: The ID of the workspace to recalculate.
+    ///
+    /// # Returns
+    /// A `Result` indicating success, or an error.
+    pub fn recalculate_layout(&mut self, workspace_id: WorkspaceId) -> Result<(), WindowManagerError> {
+        let workspace = self.workspaces.get(&workspace_id)
+            .ok_or_else(|| {
+                error!("Workspace ID {} not found during layout recalculation.", workspace_id);
+                WindowManagerError::Other(format!("Workspace {} not found for layout", workspace_id))
+            })?;
+
+        let screen_info = ScreenInfo { width: 1920.0, height: 1080.0 };
+
+        debug!("Recalculating layout for workspace {} ({}) using {:?} on screen {}x{}",
+            workspace.id, workspace.name, workspace.current_layout, screen_info.width, screen_info.height);
+
+        let mut tiled_windows_in_workspace: Vec<&WindowInfo> = Vec::new();
+        for id_in_ws in &workspace.windows {
+            if let Some(win_info) = self.windows.get(id_in_ws) {
+                if win_info.state == WindowState::Tiled {
+                    tiled_windows_in_workspace.push(win_info);
+                }
+            } else {
+                warn!("Window ID {} found in workspace {} but not in main window map.", id_in_ws, workspace_id);
+            }
+        }
+
+        if tiled_windows_in_workspace.is_empty() {
+            debug!("No tiled windows in workspace {} to arrange.", workspace_id);
+            return Ok(());
+        }
+
+        let new_rects = match workspace.current_layout {
+            TilingLayout::Tall => Self::calculate_tall_layout(&screen_info, &tiled_windows_in_workspace),
+            TilingLayout::Grid => Self::calculate_grid_layout(&screen_info, &tiled_windows_in_workspace),
+            TilingLayout::Fibonacci => {
+                warn!("Fibonacci layout is not yet implemented for workspace {}. Defaulting to Tall.", workspace_id);
+                Self::calculate_tall_layout(&screen_info, &tiled_windows_in_workspace)
+            }
+        }?;
+
+        if new_rects.len() != tiled_windows_in_workspace.len() {
+            error!("Layout algorithm returned {} rects for {} windows in workspace {}.", new_rects.len(), tiled_windows_in_workspace.len(), workspace_id);
+            return Err(WindowManagerError::LayoutCalculation("Mismatch between windows and rectangles".to_string()));
+        }
+
+        for (window_info_ref, new_rect) in tiled_windows_in_workspace.iter().zip(new_rects) {
+            if let Some(mutable_window_info) = self.windows.get_mut(&window_info_ref.id) {
+                mutable_window_info.rect = new_rect;
+                debug!("Updated window {} rect to: {:?}", mutable_window_info.id, new_rect);
+            }
+        }
+
+        info!("Layout recalculated and applied for workspace {}", workspace_id);
+        Ok(())
+    }
+
+    /// Switches the active workspace.
+    ///
+    /// # Arguments
+    /// * `target_workspace_id`: The ID of the workspace to switch to.
+    ///
+    /// # Returns
+    /// A `Result` indicating success, or an error.
+    pub fn switch_workspace(&mut self, target_workspace_id: WorkspaceId) -> Result<(), WindowManagerError> {
+        if !self.workspaces.contains_key(&target_workspace_id) {
+            warn!("Attempted to switch to non-existent workspace: {}", target_workspace_id);
+            return Err(WindowManagerError::Other(format!("Workspace {} does not exist", target_workspace_id)));
+        }
+
+        if self.active_workspace_id == target_workspace_id {
+            debug!("Attempted to switch to already active workspace: {}", target_workspace_id);
+            return Ok(());
+        }
+
+        info!("Switching active workspace from {} to {}", self.active_workspace_id, target_workspace_id);
+        self.active_workspace_id = target_workspace_id;
+        self.recalculate_layout(self.active_workspace_id)?;
+        Ok(())
+    }
+
+    /// Sets the state of a specific window.
+    ///
+    /// # Arguments
+    /// * `window_id`: The ID of the window.
+    /// * `new_state`: The new `WindowState` to apply.
+    ///
+    /// # Returns
+    /// A `Result` indicating success, or `InvalidWindowId`.
+    pub fn set_window_state(&mut self, window_id: WindowId, new_state: WindowState) -> Result<(), WindowManagerError> {
+        let window_info = self.windows.get_mut(&window_id)
+            .ok_or_else(|| {
+                warn!("Cannot set state for non-existent window: {}", window_id);
+                WindowManagerError::InvalidWindowId(window_id.to_string())
+            })?;
+
+        if window_info.state == new_state {
+            debug!("Window {} is already in state {:?}. No change.", window_id, new_state);
+            return Ok(());
+        }
+
+        info!("Setting window {} state from {:?} to {:?}", window_id, window_info.state, new_state);
+        window_info.state = new_state;
+
+        let mut parent_workspace_id: Option<WorkspaceId> = None;
+        for (ws_id, ws_info) in &self.workspaces {
+            if ws_info.windows.contains(&window_id) {
+                parent_workspace_id = Some(*ws_id);
+                break;
+            }
+        }
+
+        if let Some(ws_id) = parent_workspace_id {
+            debug!("Recalculating layout for workspace {} due to window {} state change.", ws_id, window_id);
+            self.recalculate_layout(ws_id)?;
+        } else {
+            warn!("Window {} changed state but was not found in any workspace.", window_id);
+        }
+        Ok(())
+    }
+
+    // --- Static Layout Calculation Methods ---
+    pub(crate) fn calculate_tall_layout(
+        screen: &ScreenInfo,
+        windows_in_layout: &[&WindowInfo],
+    ) -> Result<Vec<WindowRect>, WindowManagerError> {
+        if windows_in_layout.is_empty() {
+            return Ok(Vec::new());
+        }
+        let num_windows = windows_in_layout.len();
+        let mut rects = Vec::with_capacity(num_windows);
+        let master_width_ratio = 0.6;
+        let master_width = screen.width * master_width_ratio;
+        let stack_width = screen.width * (1.0 - master_width_ratio);
+
+        rects.push(WindowRect {
+            origin: Point::new(0.0, 0.0),
+            size: Size::new(master_width, screen.height),
+        });
+
+        if num_windows > 1 {
+            let num_stack_windows = num_windows - 1;
+            let stack_window_height = screen.height / num_stack_windows as f64;
+            for i in 0..num_stack_windows {
+                rects.push(WindowRect {
+                    origin: Point::new(master_width, i as f64 * stack_window_height),
+                    size: Size::new(stack_width, stack_window_height),
+                });
+            }
+        }
+        debug!("Calculated Tall layout for {} windows on screen {}x{}", num_windows, screen.width, screen.height);
+        Ok(rects)
+    }
+
+    pub(crate) fn calculate_grid_layout(
+        screen: &ScreenInfo,
+        windows_in_layout: &[&WindowInfo],
+    ) -> Result<Vec<WindowRect>, WindowManagerError> {
+        if windows_in_layout.is_empty() {
+            return Ok(Vec::new());
+        }
+        let num_windows = windows_in_layout.len();
+        let mut rects = Vec::with_capacity(num_windows);
+        let cols = (num_windows as f64).sqrt().ceil() as usize;
+        let rows = (num_windows as f64 / cols as f64).ceil() as usize;
+
+        if cols == 0 || rows == 0 {
+            return Err(WindowManagerError::LayoutCalculation(
+                format!("Grid layout: Invalid column ({}) or row ({}) count for {} windows.", cols, rows, num_windows)
+            ));
+        }
+        let cell_width = screen.width / cols as f64;
+        let cell_height = screen.height / rows as f64;
+
+        for i in 0..num_windows {
+            let row_idx = i / cols;
+            let col_idx = i % cols;
+            rects.push(WindowRect {
+                origin: Point::new(col_idx as f64 * cell_width, row_idx as f64 * cell_height),
+                size: Size::new(cell_width, cell_height),
+            });
+        }
+        debug!("Calculated Grid layout for {} windows on screen {}x{}", num_windows, screen.width, screen.height);
+        Ok(rects)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use novade_core::types::geometry::{Point, Size};
+
+    fn setup_manager() -> WindowManager {
+        WindowManager::new().expect("Failed to create WindowManager for testing")
+    }
+
+    #[test]
+    fn window_manager_new_initializes_default_workspace() {
+        let manager = setup_manager();
+        assert_eq!(manager.windows.len(), 0);
+        assert_eq!(manager.workspaces.len(), 1);
+        let active_ws_id = manager.active_workspace_id;
+        let default_ws = manager.workspaces.get(&active_ws_id).unwrap();
+        assert_eq!(default_ws.name, "Workspace 1");
+        assert_eq!(default_ws.current_layout, TilingLayout::Tall);
+    }
+
+    #[test]
+    fn on_new_window_adds_to_active_workspace_and_recalculates() {
+        let mut manager = setup_manager();
+        let initial_active_ws_id = manager.active_workspace_id;
+        let window_title = "Test Window 1".to_string();
+        let result = manager.on_new_window(window_title.clone());
+        assert!(result.is_ok());
+        let window_id = result.unwrap();
+
+        assert!(manager.windows.contains_key(&window_id));
+        let window_info = manager.windows.get(&window_id).unwrap();
+        assert_eq!(window_info.title, window_title);
+        assert_eq!(window_info.state, WindowState::Tiled);
+
+        let active_workspace = manager.workspaces.get(&initial_active_ws_id).unwrap();
+        assert!(active_workspace.windows.contains(&window_id));
+        assert_eq!(active_workspace.windows.len(), 1);
+
+        let expected_width = 1920.0 * 0.6;
+        assert_eq!(window_info.rect.origin, Point::new(0.0, 0.0));
+        assert_eq!(window_info.rect.size, Size::new(expected_width, 1080.0));
+    }
+
+    #[test]
+    fn on_new_window_multiple_windows_trigger_layout() {
+        let mut manager = setup_manager();
+        let active_ws_id = manager.active_workspace_id;
+        let id1 = manager.on_new_window("W1".to_string()).unwrap();
+        let id2 = manager.on_new_window("W2".to_string()).unwrap();
+
+        let ws = manager.workspaces.get(&active_ws_id).unwrap();
+        assert_eq!(ws.windows.len(), 2);
+
+        let win1_info = manager.windows.get(&id1).unwrap();
+        let win2_info = manager.windows.get(&id2).unwrap();
+        let master_width = 1920.0 * 0.6;
+        let stack_width = 1920.0 * 0.4;
+
+        assert_eq!(win1_info.rect.size, Size::new(master_width, 1080.0));
+        assert_eq!(win2_info.rect.origin, Point::new(master_width, 0.0));
+        assert_eq!(win2_info.rect.size, Size::new(stack_width, 1080.0));
+    }
+
+    #[test]
+    fn on_window_closed_removes_from_manager_and_workspace() {
+        let mut manager = setup_manager();
+        let window_id = manager.on_new_window("Test Window".to_string()).unwrap();
+        let initial_active_ws_id = manager.active_workspace_id;
+
+        assert!(manager.windows.contains_key(&window_id));
+        assert!(manager.workspaces.get(&initial_active_ws_id).unwrap().windows.contains(&window_id));
+
+        let close_result = manager.on_window_closed(&window_id);
+        assert!(close_result.is_ok());
+
+        assert!(!manager.windows.contains_key(&window_id));
+        let active_workspace_after_close = manager.workspaces.get(&initial_active_ws_id).unwrap();
+        assert!(!active_workspace_after_close.windows.contains(&window_id));
+        assert!(active_workspace_after_close.windows.is_empty());
+    }
+
+    #[test]
+    fn on_window_closed_non_existent_id() {
+        let mut manager = setup_manager();
+        let fake_window_id = WindowId::new_v4();
+        let result = manager.on_window_closed(&fake_window_id);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            WindowManagerError::InvalidWindowId(id_str) => assert_eq!(id_str, fake_window_id.to_string()),
+            _ => panic!("Expected InvalidWindowId error"),
+        }
+    }
+
+    #[test]
+    fn on_window_closed_recalculates_layout_for_remaining() {
+        let mut manager = setup_manager();
+        let active_ws_id = manager.active_workspace_id;
+        let id1 = manager.on_new_window("W1".to_string()).unwrap();
+        let id2 = manager.on_new_window("W2".to_string()).unwrap();
+
+        let close_result = manager.on_window_closed(&id2);
+        assert!(close_result.is_ok());
+
+        let ws = manager.workspaces.get(&active_ws_id).unwrap();
+        assert_eq!(ws.windows.len(), 1);
+        assert!(ws.windows.contains(&id1));
+
+        let win1_info = manager.windows.get(&id1).unwrap();
+        let expected_master_width = 1920.0 * 0.6;
+        assert_eq!(win1_info.rect.origin, Point::new(0.0, 0.0));
+        assert_eq!(win1_info.rect.size, Size::new(expected_master_width, 1080.0));
+    }
+
+    #[test]
+    fn switch_workspace_updates_active_id_and_recalculates() {
+        let mut manager = setup_manager();
+        let initial_active_id = manager.active_workspace_id;
+        let new_ws_id = WorkspaceId::new_v4();
+        let new_ws_info = WorkspaceInfo::new(new_ws_id, "Workspace 2".to_string(), TilingLayout::Grid);
+        manager.workspaces.insert(new_ws_id, new_ws_info.clone());
+
+        let window_in_new_ws_id = WindowId::new_v4();
+        let win_info = WindowInfo::new(window_in_new_ws_id, "WinInNewWS".to_string(), WindowRect::default(), WindowState::Tiled);
+        manager.windows.insert(window_in_new_ws_id, win_info);
+        manager.workspaces.get_mut(&new_ws_id).unwrap().windows.push(window_in_new_ws_id);
+
+        let switch_result = manager.switch_workspace(new_ws_id);
+        assert!(switch_result.is_ok());
+        assert_eq!(manager.active_workspace_id, new_ws_id);
+        assert_ne!(manager.active_workspace_id, initial_active_id);
+
+        let switched_win_info = manager.windows.get(&window_in_new_ws_id).unwrap();
+        assert_eq!(switched_win_info.rect.origin, Point::new(0.0,0.0));
+        assert_eq!(switched_win_info.rect.size, Size::new(1920.0,1080.0));
+    }
+
+    #[test]
+    fn switch_workspace_to_non_existent_id() {
+        let mut manager = setup_manager();
+        let fake_ws_id = WorkspaceId::new_v4();
+        let result = manager.switch_workspace(fake_ws_id);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            WindowManagerError::Other(msg) => assert!(msg.contains("does not exist")),
+            _ => panic!("Expected Other error"),
+        }
+    }
+
+    #[test]
+    fn switch_workspace_to_same_id_is_ok_and_no_op_effectively() {
+        let mut manager = setup_manager();
+        let initial_active_id = manager.active_workspace_id;
+        let win_id = manager.on_new_window("W1".to_string()).unwrap();
+        let rect_before_switch = manager.windows.get(&win_id).unwrap().rect;
+
+        let switch_result = manager.switch_workspace(initial_active_id);
+        assert!(switch_result.is_ok());
+        assert_eq!(manager.active_workspace_id, initial_active_id);
+
+        let rect_after_switch = manager.windows.get(&win_id).unwrap().rect;
+        assert_eq!(rect_before_switch, rect_after_switch);
+    }
+
+    #[test]
+    fn set_window_state_updates_state_and_recalculates() {
+        let mut manager = setup_manager();
+        let window_id = manager.on_new_window("Test Window".to_string()).unwrap();
+        let initial_rect = manager.windows.get(&window_id).unwrap().rect;
+        assert_eq!(manager.windows.get(&window_id).unwrap().state, WindowState::Tiled);
+
+        let set_state_result = manager.set_window_state(window_id, WindowState::Floating);
+        assert!(set_state_result.is_ok());
+
+        let window_info_after_state_change = manager.windows.get(&window_id).unwrap();
+        assert_eq!(window_info_after_state_change.state, WindowState::Floating);
+        // Recalculate layout should not affect floating window's preserved rect
+        // but the current implementation of recalculate_layout in the test code
+        // always updates rects for Tiled windows. If it were Floating, it would be skipped.
+        // The key here is that if it becomes Floating, the next Tiled layout won't touch it.
+        // Let's verify that by adding another tiled window.
+
+        let _window2_id = manager.on_new_window("Another Window".to_string()).unwrap();
+        let rect_of_floating_window_after_new_tiled = manager.windows.get(&window_id).unwrap().rect;
+        assert_eq!(window_info_after_state_change.rect, rect_of_floating_window_after_new_tiled, "Floating window rect should not change when other tiled windows are added/rearranged.");
+
+
+        let set_state_back_result = manager.set_window_state(window_id, WindowState::Tiled);
+        assert!(set_state_back_result.is_ok());
+        let window_info_after_tiled_again = manager.windows.get(&window_id).unwrap();
+        assert_eq!(window_info_after_tiled_again.state, WindowState::Tiled);
+        // Now that it's Tiled again, its rect should be updated by the layout.
+        // It will be the first window, so it gets the master pane.
+        let expected_master_width = 1920.0 * 0.6;
+        assert_eq!(window_info_after_tiled_again.rect.size.width, expected_master_width);
+    }
+
+    #[test]
+    fn set_window_state_for_non_existent_id() {
+        let mut manager = setup_manager();
+        let fake_window_id = WindowId::new_v4();
+        let result = manager.set_window_state(fake_window_id, WindowState::Floating);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            WindowManagerError::InvalidWindowId(id_str) => assert_eq!(id_str, fake_window_id.to_string()),
+            _ => panic!("Expected InvalidWindowId error"),
+        }
+    }
+
+    #[test]
+    fn recalculate_layout_handles_fibonacci_gracefully_for_now() {
+        let mut manager = setup_manager();
+        let active_ws_id = manager.active_workspace_id;
+        manager.workspaces.get_mut(&active_ws_id).unwrap().current_layout = TilingLayout::Fibonacci;
+        let window_id = manager.on_new_window("Test Window".to_string()).unwrap();
+
+        let window_info = manager.windows.get(&window_id).unwrap();
+        let expected_width = 1920.0 * 0.6;
+        assert_eq!(window_info.rect.origin, Point::new(0.0, 0.0));
+        assert_eq!(window_info.rect.size, Size::new(expected_width, 1080.0));
+    }
+
+    #[test]
+    fn recalculate_layout_no_tiled_windows() {
+        let mut manager = setup_manager();
+        let active_ws_id = manager.active_workspace_id;
+        let window_id = manager.on_new_window("Floating Window".to_string()).unwrap();
+
+        // Preserve its initial rect (which might be default or from a previous layout)
+        let initial_rect_before_floating = manager.windows.get(&window_id).unwrap().rect;
+        manager.set_window_state(window_id, WindowState::Floating).unwrap();
+        // After setting to floating, its rect should remain what it was.
+        let rect_after_floating = manager.windows.get(&window_id).unwrap().rect;
+        assert_eq!(initial_rect_before_floating, rect_after_floating);
+
+        let recalc_result = manager.recalculate_layout(active_ws_id);
+        assert!(recalc_result.is_ok());
+        let rect_after_recalc = manager.windows.get(&window_id).unwrap().rect;
+        // Since it's floating, recalculate_layout should not have changed its rect.
+        assert_eq!(rect_after_floating, rect_after_recalc);
+    }
+
+    // --- Tests for Tall Layout ---
+    #[test]
+    fn tall_layout_no_windows() {
+        let screen = ScreenInfo::new(1920.0, 1080.0);
+        let windows_in_layout: Vec<&WindowInfo> = Vec::new();
+        let rects = WindowManager::calculate_tall_layout(&screen, &windows_in_layout).unwrap();
+        assert!(rects.is_empty());
+    }
+
+    #[test]
+    fn tall_layout_one_window() {
+        let screen = ScreenInfo::new(1920.0, 1080.0);
+        let win_info = WindowInfo { id: WindowId::new_v4(), title: "Test".into(), rect: Default::default(), state: WindowState::Tiled };
+        let windows_in_layout = vec![&win_info];
+        let rects = WindowManager::calculate_tall_layout(&screen, &windows_in_layout).unwrap();
+        assert_eq!(rects.len(), 1);
+        let master_width = 1920.0 * 0.6;
+        assert_eq!(rects[0].origin, Point::new(0.0, 0.0));
+        assert_eq!(rects[0].size, Size::new(master_width, 1080.0));
+    }
+
+    #[test]
+    fn tall_layout_two_windows() {
+        let screen = ScreenInfo::new(1920.0, 1080.0);
+        let win1_info = WindowInfo { id: WindowId::new_v4(), title: "W1".into(), rect: Default::default(), state: WindowState::Tiled };
+        let win2_info = WindowInfo { id: WindowId::new_v4(), title: "W2".into(), rect: Default::default(), state: WindowState::Tiled };
+        let windows_in_layout = vec![&win1_info, &win2_info];
+        let rects = WindowManager::calculate_tall_layout(&screen, &windows_in_layout).unwrap();
+        assert_eq!(rects.len(), 2);
+        let master_width = 1920.0 * 0.6;
+        let stack_width = 1920.0 * 0.4;
+        assert_eq!(rects[0].origin, Point::new(0.0, 0.0));
+        assert_eq!(rects[0].size, Size::new(master_width, 1080.0));
+        assert_eq!(rects[1].origin, Point::new(master_width, 0.0));
+        assert_eq!(rects[1].size, Size::new(stack_width, 1080.0));
+    }
+
+    #[test]
+    fn tall_layout_three_windows() {
+        let screen = ScreenInfo::new(1920.0, 1080.0);
+        let win1 = WindowInfo { id: WindowId::new_v4(), title: "W1".into(), rect: Default::default(), state: WindowState::Tiled };
+        let win2 = WindowInfo { id: WindowId::new_v4(), title: "W2".into(), rect: Default::default(), state: WindowState::Tiled };
+        let win3 = WindowInfo { id: WindowId::new_v4(), title: "W3".into(), rect: Default::default(), state: WindowState::Tiled };
+        let windows_in_layout = vec![&win1, &win2, &win3];
+        let rects = WindowManager::calculate_tall_layout(&screen, &windows_in_layout).unwrap();
+        assert_eq!(rects.len(), 3);
+        let master_width = 1920.0 * 0.6;
+        let stack_width = 1920.0 * 0.4;
+        let stack_window_height = 1080.0 / 2.0;
+        assert_eq!(rects[0].origin, Point::new(0.0, 0.0));
+        assert_eq!(rects[0].size, Size::new(master_width, 1080.0));
+        assert_eq!(rects[1].origin, Point::new(master_width, 0.0));
+        assert_eq!(rects[1].size, Size::new(stack_width, stack_window_height));
+        assert_eq!(rects[2].origin, Point::new(master_width, stack_window_height));
+        assert_eq!(rects[2].size, Size::new(stack_width, stack_window_height));
+    }
+
+    // --- Tests for Grid Layout ---
+    #[test]
+    fn grid_layout_no_windows() {
+        let screen = ScreenInfo::new(1920.0, 1080.0);
+        let windows_in_layout: Vec<&WindowInfo> = Vec::new();
+        let rects = WindowManager::calculate_grid_layout(&screen, &windows_in_layout).unwrap();
+        assert!(rects.is_empty());
+    }
+
+    #[test]
+    fn grid_layout_one_window() {
+        let screen = ScreenInfo::new(1920.0, 1080.0);
+        let win_info = WindowInfo { id: WindowId::new_v4(), title: "Test".into(), rect: Default::default(), state: WindowState::Tiled };
+        let windows_in_layout = vec![&win_info];
+        let rects = WindowManager::calculate_grid_layout(&screen, &windows_in_layout).unwrap();
+        assert_eq!(rects.len(), 1);
+        assert_eq!(rects[0].origin, Point::new(0.0, 0.0));
+        assert_eq!(rects[0].size, Size::new(1920.0, 1080.0));
+    }
+
+    #[test]
+    fn grid_layout_two_windows() {
+        let screen = ScreenInfo::new(1920.0, 1080.0);
+        let win1 = WindowInfo { id: WindowId::new_v4(), title: "W1".into(), rect: Default::default(), state: WindowState::Tiled };
+        let win2 = WindowInfo { id: WindowId::new_v4(), title: "W2".into(), rect: Default::default(), state: WindowState::Tiled };
+        let windows_in_layout = vec![&win1, &win2];
+        let rects = WindowManager::calculate_grid_layout(&screen, &windows_in_layout).unwrap();
+        assert_eq!(rects.len(), 2);
+        let cell_width = 1920.0 / 2.0;
+        let cell_height = 1080.0 / 1.0;
+        assert_eq!(rects[0].origin, Point::new(0.0 * cell_width, 0.0));
+        assert_eq!(rects[0].size, Size::new(cell_width, cell_height));
+        assert_eq!(rects[1].origin, Point::new(1.0 * cell_width, 0.0));
+        assert_eq!(rects[1].size, Size::new(cell_width, cell_height));
+    }
+
+    #[test]
+    fn grid_layout_four_windows() {
+        let screen = ScreenInfo::new(1920.0, 1080.0);
+        let infos: Vec<WindowInfo> = (0..4).map(|i| WindowInfo { id: WindowId::new_v4(), title: format!("W{}", i), rect: Default::default(), state: WindowState::Tiled }).collect();
+        let window_refs: Vec<&WindowInfo> = infos.iter().collect();
+        let rects = WindowManager::calculate_grid_layout(&screen, &window_refs).unwrap();
+        assert_eq!(rects.len(), 4);
+        let cell_width = 1920.0 / 2.0;
+        let cell_height = 1080.0 / 2.0;
+        assert_eq!(rects[0].origin, Point::new(0.0 * cell_width, 0.0 * cell_height));
+        assert_eq!(rects[0].size, Size::new(cell_width, cell_height));
+        assert_eq!(rects[1].origin, Point::new(1.0 * cell_width, 0.0 * cell_height));
+        assert_eq!(rects[1].size, Size::new(cell_width, cell_height));
+        assert_eq!(rects[2].origin, Point::new(0.0 * cell_width, 1.0 * cell_height));
+        assert_eq!(rects[2].size, Size::new(cell_width, cell_height));
+        assert_eq!(rects[3].origin, Point::new(1.0 * cell_width, 1.0 * cell_height));
+        assert_eq!(rects[3].size, Size::new(cell_width, cell_height));
+    }
+
+    #[test]
+    fn grid_layout_three_windows() {
+        let screen = ScreenInfo::new(1920.0, 1080.0);
+        let infos: Vec<WindowInfo> = (0..3).map(|i| WindowInfo {id: WindowId::new_v4(), title: format!("W{}", i), rect: Default::default(), state: WindowState::Tiled }).collect();
+        let window_refs: Vec<&WindowInfo> = infos.iter().collect();
+        let rects = WindowManager::calculate_grid_layout(&screen, &window_refs).unwrap();
+        assert_eq!(rects.len(), 3);
+        let cell_width = 1920.0 / 2.0;
+        let cell_height = 1080.0 / 2.0;
+        assert_eq!(rects[0].origin, Point::new(0.0 * cell_width, 0.0 * cell_height));
+        assert_eq!(rects[0].size, Size::new(cell_width, cell_height));
+        assert_eq!(rects[1].origin, Point::new(1.0 * cell_width, 0.0 * cell_height));
+        assert_eq!(rects[1].size, Size::new(cell_width, cell_height));
+        assert_eq!(rects[2].origin, Point::new(0.0 * cell_width, 1.0 * cell_height));
+        assert_eq!(rects[2].size, Size::new(cell_width, cell_height));
+    }
+}

--- a/novade-system/src/window_mechanics/mod.rs
+++ b/novade-system/src/window_mechanics/mod.rs
@@ -1,0 +1,41 @@
+// novade-system/src/window_mechanics/mod.rs
+
+//! Manages window arrangement, sizing, and positioning, including tiling.
+//!
+//! This module implements the technical logic for window manipulation within
+//! the Wayland compositor, translating window policies from the domain layer
+//! into actions on the `smithay` compositor state.
+
+// Declare the sub-modules that will make up the window_mechanics crate part.
+pub mod data_types;
+pub mod error;
+pub mod manager;
+
+// Re-export key public types and functions for easier access from outside this module.
+// For example, if WindowManager is the main entry point:
+// pub use manager::WindowManager;
+// pub use data_types::{WindowId, WindowInfo, WindowRect, WindowState, WorkspaceId, WorkspaceInfo, ScreenInfo, TilingLayout};
+// pub use error::WindowManagerError;
+
+// Specific functions or types that are intended for public use could also be re-exported here.
+// For now, we'll keep it minimal and expand as implementations in sub-modules become concrete.
+
+// It's good practice to provide an initialization function if the module needs setup.
+// For example:
+// pub fn init(/* parameters */) -> Result<manager::WindowManager, error::WindowManagerError> {
+//     manager::WindowManager::new(/* parameters */)
+// }
+
+// Tracing for logging within this module.
+use tracing::info;
+
+/// Initializes the window mechanics module.
+///
+/// This function is a placeholder and might evolve to accept configuration
+/// or state from the main compositor. For now, it simply logs an
+/// initialization message.
+pub fn initialize_window_mechanics() {
+    // This is also a good place to ensure that logging context for this module is set up.
+    info!("Window mechanics module initializing.");
+    // In a real scenario, this might return a WindowManager instance or similar.
+}


### PR DESCRIPTION
I've added the `novade-system/src/window_mechanics` module to manage window arrangement, sizing, and positioning.

This initial implementation includes:
- `error.rs`: Defines `WindowManagerError` for specific error handling within the module.
- `data_types.rs`: Defines core data structures such as `WindowId`, `WindowRect`, `WindowState`, `WindowInfo`, `WorkspaceId`, `WorkspaceInfo`, `TilingLayout`, and `ScreenInfo`. These types use `uuid` for unique IDs and `novade_core::types::geometry` for geometric representations.
- `manager.rs`: Implements `WindowManager` with core logic for:
    - Managing a collection of windows and workspaces.
    - Creating a default workspace on initialization.
    - Handling new window registration (`on_new_window`) and window closure (`on_window_closed`).
    - Setting window states (`set_window_state`).
    - Switching active workspaces (`switch_workspace`).
    - Recalculating window layouts (`recalculate_layout`) based on `Tall` and `Grid` tiling algorithms. Fibonacci layout is defined but defaults to Tall.
- `mod.rs`: Declares the sub-modules and includes basic initialization logging.

Unit tests have been added for all three sub-modules, covering error formatting, data type construction and defaults, and the core functionalities of the `WindowManager` including layout calculations and state manipulations.

The module is integrated into `novade-system/src/lib.rs`.

Output: