### PR TITLE
feat: Implement initial Vulkan rendering module

### DIFF
--- a/novade-system/Cargo.toml
+++ b/novade-system/Cargo.toml
@@ -32,6 +32,11 @@ futures-core = "0.3"
 async-stream = "0.3"
 signal-hook = "0.3"
 polling = "3.4"
+ash = "0.37" # For Vulkan bindings
+ash-window = "0.12" # For Wayland surface creation with Ash
+gpu-allocator = { version = "0.22", features = ["ash"] } # Rust wrapper for VMA
+raw-window-handle = "0.5" # For integrating with Wayland surfaces
+
 
 [features]
 default = []
@@ -44,3 +49,7 @@ default = []
 # which is the intended outcome for a pure stub implementation.
 
 # Conditional dependency sections for libinput/udev are also removed.
+
+[[example]]
+name = "vulkan_renderer_test"
+path = "examples/vulkan_renderer_test.rs"

--- a/novade-system/assets/shaders/textured.frag
+++ b/novade-system/assets/shaders/textured.frag
@@ -1,0 +1,14 @@
+#version 450
+
+layout(location = 0) in vec2 fragTexCoord;
+
+layout(location = 0) out vec4 outColor;
+
+// ANCHOR: Texture Sampler Binding
+layout(set = 0, binding = 0) uniform sampler2D texSampler;
+
+void main() {
+    outColor = texture(texSampler, fragTexCoord);
+    // For testing without a real texture, you could output fragTexCoord:
+    // outColor = vec4(fragTexCoord, 0.0, 1.0);
+}

--- a/novade-system/assets/shaders/textured.frag.spv
+++ b/novade-system/assets/shaders/textured.frag.spv
@@ -1,0 +1,7 @@
+// This is a placeholder file.
+// It should contain the compiled SPIR-V bytecode from textured.frag.
+//
+// To compile using glslc (if installed):
+// glslc textured.frag -o textured.frag.spv
+//
+// Ensure this file is replaced with actual SPIR-V code for the renderer to work.

--- a/novade-system/assets/shaders/textured.vert
+++ b/novade-system/assets/shaders/textured.vert
@@ -1,0 +1,11 @@
+#version 450
+
+layout(location = 0) in vec2 inPosition;
+layout(location = 1) in vec2 inTexCoord;
+
+layout(location = 0) out vec2 fragTexCoord;
+
+void main() {
+    gl_Position = vec4(inPosition, 0.0, 1.0);
+    fragTexCoord = inTexCoord;
+}

--- a/novade-system/assets/shaders/textured.vert.spv
+++ b/novade-system/assets/shaders/textured.vert.spv
@@ -1,0 +1,7 @@
+// This is a placeholder file.
+// It should contain the compiled SPIR-V bytecode from textured.vert.
+//
+// To compile using glslc (if installed):
+// glslc textured.vert -o textured.vert.spv
+//
+// Ensure this file is replaced with actual SPIR-V code for the renderer to work.

--- a/novade-system/examples/vulkan_renderer_test.rs
+++ b/novade-system/examples/vulkan_renderer_test.rs
@@ -1,0 +1,107 @@
+// novade-system/examples/vulkan_renderer_test.rs
+
+// ANCHOR: Use Statements
+use novade_system::renderers::vulkan::NovaVulkanRenderer;
+use std::ffi::c_void;
+use std::thread;
+use std::time::Duration;
+
+// ANCHOR: Main Function
+fn main() {
+    println!("Starting NovaVulkanRenderer test...");
+
+    // ANCHOR_EXT: Renderer Initialization
+    // Using null pointers for Wayland handles as this is a non-displaying test.
+    // This will likely cause surface/swapchain creation to fail, but we want to test
+    // how much of the renderer can initialize and if it handles such failures gracefully.
+    let mut renderer = match NovaVulkanRenderer::new(std::ptr::null_mut() as *mut c_void, std::ptr::null_mut() as *mut c_void) {
+        Ok(r) => {
+            println!("NovaVulkanRenderer created successfully.");
+            r
+        }
+        Err(e) => {
+            eprintln!("Failed to create NovaVulkanRenderer: {}", e);
+            // Depending on the error, some parts of VulkanContext might still be alive.
+            // For this test, we'll exit if the core renderer can't be made.
+            return;
+        }
+    };
+
+    // ANCHOR_EXT: Swapchain Initialization (Attempt 1)
+    let initial_width = 800;
+    let initial_height = 600;
+    println!("\nAttempting initial swapchain initialization ({}x{})...", initial_width, initial_height);
+    match renderer.init_swapchain(initial_width, initial_height) {
+        Ok(()) => {
+            println!("Initial swapchain initialization successful.");
+
+            // ANCHOR_EXT: Render Loop (Attempt 1)
+            println!("\nStarting render loop (10 frames)...");
+            for i in 0..10 {
+                print!("Rendering frame {}... ", i + 1);
+                match renderer.render_frame() {
+                    Ok(()) => println!("Done."),
+                    Err(e) => {
+                        eprintln!("Error during render_frame: {}", e);
+                        // If render_frame fails (e.g. swapchain out of date and recreation not fully implemented)
+                        // we might want to break the loop or attempt recreation here.
+                        // For this test, we'll log and continue to see if it recovers or consistently fails.
+                        if e.contains("Swapchain out of date") {
+                             println!("Swapchain out of date, attempting recreation for next frame simulation might be needed.");
+                             // In a real app, signal for swapchain recreation.
+                        }
+                    }
+                }
+                // thread::sleep(Duration::from_millis(16)); // Simulate frame delay
+            }
+            println!("Render loop finished.");
+
+        }
+        Err(e) => {
+            eprintln!("Failed to initialize swapchain (initial attempt): {}", e);
+            println!("This is expected if Wayland handles are null and surface creation fails.");
+            println!("Skipping render loop and resize test due to swapchain initialization failure.");
+        }
+    }
+
+
+    // ANCHOR_EXT: Swapchain Recreation Test (Attempt 2, if initial succeeded)
+    // This section will only be meaningful if the first init_swapchain was successful.
+    // If surface creation is the blocker, this will also likely fail or be skipped.
+    if renderer.swapchain.is_some() { // Check if swapchain was successfully created
+        let new_width = 1024;
+        let new_height = 768;
+        println!("\nAttempting swapchain recreation ({}x{})...", new_width, new_height);
+        match renderer.init_swapchain(new_width, new_height) {
+            Ok(()) => {
+                println!("Swapchain recreation successful.");
+
+                println!("\nStarting render loop after recreation (5 frames)...");
+                for i in 0..5 {
+                    print!("Rendering frame {} (post-recreation)... ", i + 1);
+                    match renderer.render_frame() {
+                        Ok(()) => println!("Done."),
+                        Err(e) => {
+                            eprintln!("Error during render_frame (post-recreation): {}", e);
+                             if e.contains("Swapchain out of date") {
+                                println!("Swapchain out of date, attempting recreation for next frame simulation might be needed.");
+                            }
+                        }
+                    }
+                    // thread::sleep(Duration::from_millis(16));
+                }
+                println!("Render loop (post-recreation) finished.");
+            }
+            Err(e) => {
+                eprintln!("Failed to recreate swapchain: {}", e);
+            }
+        }
+    } else {
+        println!("\nSkipping swapchain recreation test as initial swapchain was not created.");
+    }
+
+
+    // ANCHOR_EXT: Cleanup
+    // `renderer` goes out of scope here, its `Drop` implementation will be called.
+    println!("\nTest finished. Renderer cleanup will now occur via Drop.");
+}

--- a/novade-system/src/renderers/vulkan/buffer.rs
+++ b/novade-system/src/renderers/vulkan/buffer.rs
@@ -1,0 +1,150 @@
+use ash::{vk, Device as AshDevice};
+use gpu_allocator::vulkan as vma;
+use gpu_allocator::MemoryUsage as GpuMemoryUsage;
+use std::sync::{Arc, Mutex};
+
+// ANCHOR: VulkanBuffer Struct Definition
+pub struct VulkanBuffer {
+    device: Arc<AshDevice>,
+    allocator: Arc<Mutex<vma::Allocator>>,
+    pub buffer: vk::Buffer, // Made public for easy access in command recording
+    allocation: Option<vma::Allocation>, // Option to allow taking it in drop
+    pub size: vk::DeviceSize, // Made public for information
+}
+
+// ANCHOR: VulkanBuffer Implementation
+impl VulkanBuffer {
+    pub fn new(
+        device: Arc<AshDevice>,
+        allocator: Arc<Mutex<vma::Allocator>>,
+        size: vk::DeviceSize,
+        usage: vk::BufferUsageFlags,
+        memory_usage: GpuMemoryUsage, // e.g., CpuToGpu, GpuOnly
+    ) -> Result<Self, String> {
+        if size == 0 {
+            return Err("Buffer size cannot be zero.".to_string());
+        }
+
+        let buffer_create_info = vk::BufferCreateInfo::builder()
+            .size(size)
+            .usage(usage)
+            .sharing_mode(vk::SharingMode::EXCLUSIVE) // Or CONCURRENT if needed across queue families
+            .build();
+
+        let allocation_create_info = vma::AllocationCreateInfo {
+            usage: memory_usage,
+            // flags, required_flags, preferred_flags, pool can be specified if needed
+            ..Default::default()
+        };
+
+        let (buffer, allocation) = unsafe {
+            allocator
+                .lock()
+                .map_err(|_| "Failed to lock allocator mutex".to_string())?
+                .create_buffer(&buffer_create_info, &allocation_create_info)
+                .map_err(|e| format!("VMA failed to create buffer: {:?}", e))?
+        };
+
+        Ok(Self {
+            device,
+            allocator,
+            buffer,
+            allocation: Some(allocation),
+            size,
+        })
+    }
+
+    // ANCHOR_EXT: fill_from_slice
+    /// Fills a portion of the buffer from a slice.
+    /// The buffer must have been created with memory_usage that is HOST_VISIBLE (e.g., CpuToGpu, CpuOnly).
+    /// T is the type of elements in the slice.
+    pub fn fill_from_slice<T: Copy>(&self, data: &[T], slice_offset_bytes: vk::DeviceSize) -> Result<(), String> {
+        let data_size_bytes = (data.len() * std::mem::size_of::<T>()) as vk::DeviceSize;
+        if data_size_bytes == 0 {
+            return Ok(()); // Nothing to copy
+        }
+        if slice_offset_bytes + data_size_bytes > self.size {
+            return Err(format!(
+                "Data slice (offset: {}, size: {}) exceeds buffer bounds (size: {}).",
+                slice_offset_bytes, data_size_bytes, self.size
+            ));
+        }
+
+        let allocation = self.allocation.as_ref()
+            .ok_or_else(|| "Buffer allocation is None, cannot map memory.".to_string())?;
+
+        // Check if memory is host visible (mappable)
+        // This check relies on how gpu-allocator sets memory properties.
+        // A more robust check might involve querying allocation.memory_properties().
+        if !allocation.is_host_visible() {
+             return Err("Buffer memory is not host visible, cannot map for filling.".to_string());
+        }
+
+
+        let mapped_ptr = unsafe {
+            allocation.map(self.device.as_ref(), slice_offset_bytes, data_size_bytes)
+                .map_err(|e| format!("Failed to map buffer memory: {:?}", e))?
+        };
+
+        unsafe {
+            // Assuming mapped_ptr is already correctly offset by allocation.map()
+            // or that slice_offset_bytes for map was 0 and we handle offset here.
+            // gpu_allocator's map function signature is `map(device, offset_in_allocation, size_to_map)`
+            // So mapped_ptr is already at the correct offset within the allocation.
+            std::ptr::copy_nonoverlapping(
+                data.as_ptr() as *const std::ffi::c_void,
+                mapped_ptr.as_ptr() as *mut std::ffi::c_void,
+                data_size_bytes as usize,
+            );
+        }
+
+        // Flush memory if it's not coherent and host visible
+        if allocation.needs_flush() {
+            unsafe {
+                allocation.flush(self.device.as_ref(), slice_offset_bytes, data_size_bytes)
+                    .map_err(|e| format!("Failed to flush mapped buffer memory: {:?}", e))?;
+            }
+        }
+
+        unsafe {
+            allocation.unmap(self.device.as_ref());
+        }
+
+        Ok(())
+    }
+
+    // ANCHOR: Accessor for vk::Buffer
+    pub fn handle(&self) -> vk::Buffer {
+        self.buffer
+    }
+
+    // ANCHOR: Accessor for size
+    pub fn size(&self) -> vk::DeviceSize {
+        self.size
+    }
+}
+
+// ANCHOR: VulkanBuffer Drop Implementation
+impl Drop for VulkanBuffer {
+    fn drop(&mut self) {
+        if let Some(allocation) = self.allocation.take() { // Take ownership of allocation
+            //println!("Dropping VulkanBuffer: {:?}, Allocation: {:?}", self.buffer, allocation.info());
+            if let Ok(mut allocator_guard) = self.allocator.lock() {
+                unsafe {
+                    allocator_guard.destroy_buffer(self.buffer, allocation)
+                        .unwrap_or_else(|e| eprintln!("VMA failed to destroy buffer: {:?}", e));
+                }
+            } else {
+                eprintln!("VulkanBuffer::drop: Failed to lock allocator mutex. Buffer and allocation may leak.");
+                // If mutex is poisoned, resources might leak. Consider alternative cleanup or panic.
+            }
+        } else {
+            // This case should ideally not happen if allocation is always Some after new()
+            // and only taken in drop. If it can be None otherwise, ensure no vkDestroyBuffer is called
+            // without an allocator context if it was VMA managed.
+            // If the buffer was not created by VMA (e.g. external), then this Drop is not appropriate.
+            // For now, we assume all VulkanBuffer instances here own their allocation.
+            // println!("VulkanBuffer::drop called on a buffer with no VMA allocation. Buffer handle: {:?}", self.buffer);
+        }
+    }
+}

--- a/novade-system/src/renderers/vulkan/command_buffer.rs
+++ b/novade-system/src/renderers/vulkan/command_buffer.rs
@@ -47,3 +47,136 @@ pub fn end_single_time_commands(
     }
     Ok(())
 }
+
+// ANCHOR: copy_buffer_to_buffer_sync
+pub fn copy_buffer_to_buffer_sync(
+    device: &ash::Device,
+    command_pool: vk::CommandPool,
+    queue: vk::Queue,
+    src_buffer: vk::Buffer,
+    dst_buffer: vk::Buffer,
+    size: vk::DeviceSize,
+) -> Result<(), String> {
+    let command_buffer = begin_single_time_commands(device, command_pool)?;
+
+    let copy_region = vk::BufferCopy::builder().size(size).build(); // src_offset and dst_offset are 0
+    unsafe {
+        device.cmd_copy_buffer(command_buffer, src_buffer, dst_buffer, &[copy_region]);
+    }
+
+    end_single_time_commands(device, command_pool, command_buffer, queue)?;
+    Ok(())
+}
+
+// ANCHOR: transition_image_layout_sync
+pub fn transition_image_layout_sync(
+    device: &ash::Device,
+    command_pool: vk::CommandPool,
+    queue: vk::Queue,
+    image: vk::Image,
+    aspect_mask: vk::ImageAspectFlags,
+    mip_levels: u32,
+    old_layout: vk::ImageLayout,
+    new_layout: vk::ImageLayout,
+) -> Result<(), String> {
+    let command_buffer = begin_single_time_commands(device, command_pool)?;
+
+    let mut barrier = vk::ImageMemoryBarrier::builder()
+        .old_layout(old_layout)
+        .new_layout(new_layout)
+        .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+        .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+        .image(image)
+        .subresource_range(
+            vk::ImageSubresourceRange::builder()
+                .aspect_mask(aspect_mask)
+                .base_mip_level(0)
+                .level_count(mip_levels)
+                .base_array_layer(0)
+                .layer_count(1)
+                .build(),
+        );
+
+    // Set access masks based on layouts
+    // This is a simplified version; more specific masks might be needed for complex scenarios.
+    let (src_access_mask, dst_access_mask, src_stage, dst_stage) =
+        match (old_layout, new_layout) {
+            (vk::ImageLayout::UNDEFINED, vk::ImageLayout::TRANSFER_DST_OPTIMAL) => (
+                vk::AccessFlags::empty(),
+                vk::AccessFlags::TRANSFER_WRITE,
+                vk::PipelineStageFlags::TOP_OF_PIPE,
+                vk::PipelineStageFlags::TRANSFER,
+            ),
+            (vk::ImageLayout::TRANSFER_DST_OPTIMAL, vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL) => (
+                vk::AccessFlags::TRANSFER_WRITE,
+                vk::AccessFlags::SHADER_READ,
+                vk::PipelineStageFlags::TRANSFER,
+                vk::PipelineStageFlags::FRAGMENT_SHADER,
+            ),
+            // Add other common transitions as needed
+            _ => {
+                return Err(format!(
+                    "Unsupported layout transition from {:?} to {:?}",
+                    old_layout, new_layout
+                ));
+            }
+        };
+
+    barrier = barrier.src_access_mask(src_access_mask).dst_access_mask(dst_access_mask);
+
+    unsafe {
+        device.cmd_pipeline_barrier(
+            command_buffer,
+            src_stage,
+            dst_stage,
+            vk::DependencyFlags::empty(),
+            &[], // No memory barriers
+            &[], // No buffer memory barriers
+            &[barrier.build()],
+        );
+    }
+
+    end_single_time_commands(device, command_pool, command_buffer, queue)?;
+    Ok(())
+}
+
+// ANCHOR: copy_buffer_to_image_sync
+pub fn copy_buffer_to_image_sync(
+    device: &ash::Device,
+    command_pool: vk::CommandPool,
+    queue: vk::Queue,
+    src_buffer: vk::Buffer,
+    dst_image: vk::Image,
+    extent: vk::Extent3D, // width, height, depth of the image region to copy
+) -> Result<(), String> {
+    let command_buffer = begin_single_time_commands(device, command_pool)?;
+
+    let region = vk::BufferImageCopy::builder()
+        .buffer_offset(0)
+        .buffer_row_length(0) // Tightly packed
+        .buffer_image_height(0) // Tightly packed
+        .image_subresource(
+            vk::ImageSubresourceLayers::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .mip_level(0)
+                .base_array_layer(0)
+                .layer_count(1)
+                .build(),
+        )
+        .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+        .image_extent(extent)
+        .build();
+
+    unsafe {
+        device.cmd_copy_buffer_to_image(
+            command_buffer,
+            src_buffer,
+            dst_image,
+            vk::ImageLayout::TRANSFER_DST_OPTIMAL, // Image must be in this layout
+            &[region],
+        );
+    }
+
+    end_single_time_commands(device, command_pool, command_buffer, queue)?;
+    Ok(())
+}

--- a/novade-system/src/renderers/vulkan/context.rs
+++ b/novade-system/src/renderers/vulkan/context.rs
@@ -1,0 +1,624 @@
+use ash::{vk, Entry, Instance};
+use gpu_allocator::vulkan as vma; // Or direct VMA bindings
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use std::sync::Arc;
+use std::borrow::Cow; // Added for debug message strings
+
+// Assuming sync module is at super::sync relative to this file (context.rs)
+// This needs to be at the crate root or correctly pathed if context.rs is not directly in renderers::vulkan
+// For now, let's assume it will be available at this path:
+use super::sync::FrameSyncPrimitives;
+
+// ANCHOR: MAX_FRAMES_IN_FLIGHT Constant
+const MAX_FRAMES_IN_FLIGHT: usize = 2;
+
+// ANCHOR: VulkanContext Struct Definition
+pub struct VulkanContext {
+    entry: Entry,
+    instance: Arc<Instance>, // Changed to Arc<Instance>
+    debug_messenger: Option<vk::DebugUtilsMessengerEXT>,
+    debug_utils_loader: Option<ash::extensions::ext::DebugUtils>,
+    physical_device: vk::PhysicalDevice,
+    device: Arc<ash::Device>, // Arc for easier sharing with VMA and other parts
+    graphics_queue_family_index: u32,
+    present_queue_family_index: u32,
+    graphics_queue: vk::Queue,
+    present_queue: vk::Queue,
+    allocator: Arc<std::sync::Mutex<vma::Allocator>>, // Mutex for interior mutability with Arc
+
+    // ANCHOR_EXT: New fields for command buffers and sync
+    command_pool: vk::CommandPool,
+    command_buffers: Vec<vk::CommandBuffer>,
+    per_frame_sync_primitives: Vec<FrameSyncPrimitives>,
+    current_frame_index: usize,
+}
+
+// ANCHOR: Debug Callback Function
+unsafe extern "system" fn vulkan_debug_callback(
+    message_severity: vk::DebugUtilsMessageSeverityFlagsEXT,
+    message_type: vk::DebugUtilsMessageTypeFlagsEXT,
+    p_callback_data: *const vk::DebugUtilsMessengerCallbackDataEXT,
+    _p_user_data: *mut std::ffi::c_void,
+) -> vk::Bool32 {
+    let callback_data = *p_callback_data;
+    let message_id_number: i32 = callback_data.message_id_number as i32;
+    let message_id_name = if callback_data.p_message_id_name.is_null() {
+        Cow::from("")
+    } else {
+        CStr::from_ptr(callback_data.p_message_id_name).to_string_lossy()
+    };
+    let message = if callback_data.p_message.is_null() {
+        Cow::from("")
+    } else {
+        CStr::from_ptr(callback_data.p_message).to_string_lossy()
+    };
+    println!(
+        "{:?}:
+{:?} [{} ({})] : {}
+",
+        message_severity,
+        message_type,
+        message_id_name,
+        &message_id_number.to_string(),
+        message,
+    );
+    vk::FALSE
+}
+
+
+// ANCHOR: VulkanContext Implementation
+impl VulkanContext {
+    pub fn new() -> Result<Self, String> {
+        let entry = Entry::linked();
+
+        // ANCHOR: Instance Creation
+        let app_name = CString::new("NovaDE").unwrap();
+        let engine_name = CString::new("NovaDE Engine").unwrap();
+        let app_info = vk::ApplicationInfo::builder()
+            .application_name(&app_name)
+            .application_version(vk::make_api_version(0, 0, 1, 0))
+            .engine_name(&engine_name)
+            .engine_version(vk::make_api_version(0, 0, 1, 0))
+            .api_version(vk::API_VERSION_1_3);
+
+        let mut instance_extensions = vec![
+            ash::extensions::khr::Surface::name().as_ptr(),
+            ash::extensions::khr::WaylandSurface::name().as_ptr(),
+            ash::extensions::ext::DebugUtils::name().as_ptr(),
+        ];
+
+        let mut required_validation_layers = Vec::new();
+        if cfg!(debug_assertions) {
+            required_validation_layers.push(CString::new("VK_LAYER_KHRONOS_validation").unwrap());
+        }
+
+        let required_validation_layers_raw: Vec<*const c_char> = required_validation_layers
+            .iter()
+            .map(|layer_name| layer_name.as_ptr())
+            .collect();
+
+        let instance_create_info = vk::InstanceCreateInfo::builder()
+            .application_info(&app_info)
+            .enabled_extension_names(&instance_extensions)
+            .enabled_layer_names(&required_validation_layers_raw);
+
+        let instance_ash = unsafe { // Renamed to instance_ash to avoid conflict before Arc
+            entry.create_instance(&instance_create_info, None)
+        }.map_err(|e| format!("Failed to create Vulkan instance: {}", e))?;
+        let instance = Arc::new(instance_ash); // Wrap in Arc
+
+        // ANCHOR: Debug Messenger Setup
+        let mut debug_messenger = None;
+        let mut debug_utils_loader = None;
+        if cfg!(debug_assertions) {
+            let debug_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+                .message_severity(
+                    vk::DebugUtilsMessageSeverityFlagsEXT::ERROR
+                        | vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
+                        // | vk::DebugUtilsMessageSeverityFlagsEXT::INFO // Optional: reduce verbosity
+                        // | vk::DebugUtilsMessageSeverityFlagsEXT::VERBOSE // Optional: reduce verbosity
+                )
+                .message_type(
+                    vk::DebugUtilsMessageTypeFlagsEXT::GENERAL
+                        | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION
+                        | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE,
+                )
+                .pfn_user_callback(Some(vulkan_debug_callback));
+
+            let loader = ash::extensions::ext::DebugUtils::new(&entry, instance.as_ref()); // Use instance.as_ref()
+            let messenger = unsafe {
+                loader.create_debug_utils_messenger(&debug_info, None)
+            }.map_err(|e| format!("Failed to create debug messenger: {}", e))?;
+            debug_messenger = Some(messenger);
+            debug_utils_loader = Some(loader);
+            println!("Vulkan debug messenger created.");
+        }
+
+        // ANCHOR: Physical Device Selection
+        let physical_devices = unsafe {
+            instance.enumerate_physical_devices()
+        }.map_err(|e| format!("Failed to enumerate physical devices: {}", e))?;
+
+        if physical_devices.is_empty() {
+            return Err("No Vulkan-compatible physical devices found.".to_string());
+        }
+
+        let mut chosen_device_info = None;
+
+        for device in physical_devices {
+            let properties = unsafe { instance.get_physical_device_properties(device) };
+            let features = unsafe { instance.get_physical_device_features(device) };
+            let queue_families = unsafe { instance.get_physical_device_queue_family_properties(device) };
+
+            // Prioritize AMD Vega 8 Integrated GPU
+            let is_amd_vega_8 = properties.vendor_id == 0x1002 && properties.device_type == vk::PhysicalDeviceType::INTEGRATED_GPU;
+            // A more generic check could be added here if specific device name is known and properties.device_name can be checked.
+
+            if Self::is_device_suitable(device, &instance, &queue_families, is_amd_vega_8) {
+                if let Some((graphics_index, present_index)) = Self::find_queue_families(&instance, device, &queue_families) {
+                    // If it's the preferred device, take it immediately
+                    if is_amd_vega_8 {
+                        chosen_device_info = Some((device, graphics_index, present_index, properties.device_name_as_c_str().unwrap().to_string_lossy().into_owned()));
+                        break;
+                    }
+                    // Otherwise, store it and continue searching for a potentially better one (the preferred one)
+                    if chosen_device_info.is_none() {
+                         chosen_device_info = Some((device, graphics_index, present_index, properties.device_name_as_c_str().unwrap().to_string_lossy().into_owned()));
+                    }
+                }
+            }
+        }
+
+        let (physical_device, graphics_queue_family_index, present_queue_family_index, device_name) =
+            chosen_device_info.ok_or_else(|| "No suitable physical device found.".to_string())?;
+
+        println!("Selected physical device: {} (Graphics QF: {}, Present QF: {})", device_name, graphics_queue_family_index, present_queue_family_index);
+
+        // ANCHOR: Logical Device Creation
+        let mut queue_create_infos = vec![];
+        let queue_priority = 1.0f32;
+
+        // Graphics queue
+        let graphics_queue_info = vk::DeviceQueueCreateInfo::builder()
+            .queue_family_index(graphics_queue_family_index)
+            .queue_priorities(std::slice::from_ref(&queue_priority));
+        queue_create_infos.push(graphics_queue_info);
+
+        // Present queue, only if different from graphics
+        if present_queue_family_index != graphics_queue_family_index {
+            let present_queue_info = vk::DeviceQueueCreateInfo::builder()
+                .queue_family_index(present_queue_family_index)
+                .queue_priorities(std::slice::from_ref(&queue_priority));
+            queue_create_infos.push(present_queue_info);
+        }
+
+        let device_extensions_raw = [
+            ash::extensions::khr::Swapchain::name().as_ptr(),
+            // Add other required device extensions here if any
+        ];
+
+        // Enable minimal features for now. Specific features can be enabled as needed.
+        let features = vk::PhysicalDeviceFeatures::builder();
+            // .sampler_anisotropy(true) // Example: if you need anisotropy
+            // .build();
+
+        let device_create_info = vk::DeviceCreateInfo::builder()
+            .queue_create_infos(&queue_create_infos)
+            .enabled_extension_names(&device_extensions_raw)
+            .enabled_features(&features);
+
+        let device: Arc<ash::Device> = unsafe {
+            Arc::new(instance.create_device(physical_device, &device_create_info, None)
+                .map_err(|e| format!("Failed to create logical device: {}", e))?)
+        };
+        println!("Logical device created.");
+
+        let graphics_queue = unsafe { device.get_device_queue(graphics_queue_family_index, 0) };
+        let present_queue = unsafe { device.get_device_queue(present_queue_family_index, 0) };
+        println!("Graphics and Present queues obtained.");
+
+        // ANCHOR: VMA Allocator Initialization
+        let allocator_create_info = vma::AllocatorCreateInfo::new(
+            instance.as_ref(), // Use instance.as_ref()
+            &device,
+            physical_device,
+        )
+        // .flags(vma::AllocatorCreateFlags::EXT_MEMORY_BUDGET) // Example flag if needed
+        .vulkan_api_version(app_info.api_version); // Use api_version from app_info
+
+        let allocator = match vma::Allocator::new(allocator_create_info) {
+            Ok(alloc) => alloc,
+            Err(e) => return Err(format!("Failed to create VMA allocator: {:?}", e)),
+        };
+
+        let allocator_arc = Arc::new(std::sync::Mutex::new(allocator));
+        println!("VMA allocator created.");
+
+        // ANCHOR_EXT: Create Command Pool
+        let pool_create_info = vk::CommandPoolCreateInfo::builder()
+            .queue_family_index(graphics_queue_family_index)
+            .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER); // Allow resetting individual command buffers
+
+        let command_pool = unsafe {
+            device.create_command_pool(&pool_create_info, None)
+        }.map_err(|e| format!("Failed to create command pool: {}", e))?;
+        println!("Command pool created.");
+
+        // ANCHOR_EXT: Allocate Command Buffers
+        let command_buffer_allocate_info = vk::CommandBufferAllocateInfo::builder()
+            .command_pool(command_pool)
+            .level(vk::CommandBufferLevel::PRIMARY)
+            .command_buffer_count(MAX_FRAMES_IN_FLIGHT as u32);
+
+        let command_buffers = unsafe {
+            device.allocate_command_buffers(&command_buffer_allocate_info)
+        }.map_err(|e| {
+            unsafe { device.destroy_command_pool(command_pool, None); } // Cleanup pool if alloc fails
+            format!("Failed to allocate command buffers: {}", e)
+        })?;
+        println!("Command buffers allocated (count: {}).", command_buffers.len());
+
+        // ANCHOR_EXT: Create Frame Sync Primitives
+        let mut per_frame_sync_primitives = Vec::with_capacity(MAX_FRAMES_IN_FLIGHT);
+        for i in 0..MAX_FRAMES_IN_FLIGHT {
+            match FrameSyncPrimitives::new(device.clone()) {
+                Ok(sync_prim) => per_frame_sync_primitives.push(sync_prim),
+                Err(e) => {
+                    // Cleanup already created sync objects, command buffers, and pool
+                    // This is verbose; a helper function or RAII guard would be better in production
+                    for sp in per_frame_sync_primitives { drop(sp); } // Explicitly drop
+                    unsafe {
+                        // Command buffers are freed when pool is destroyed
+                        device.destroy_command_pool(command_pool, None);
+                    }
+                    return Err(format!("Failed to create FrameSyncPrimitives for frame {}: {}", i, e));
+                }
+            }
+        }
+        println!("FrameSyncPrimitives created (count: {}).", per_frame_sync_primitives.len());
+
+        Ok(Self {
+            entry,
+            instance, // This is now Arc<Instance>
+            debug_messenger,
+            debug_utils_loader,
+            physical_device,
+            device, // Actual device
+            graphics_queue_family_index,
+            present_queue_family_index,
+            graphics_queue, // Actual queue
+            present_queue,   // Actual queue
+            allocator: allocator_arc, // Actual allocator
+            command_pool,
+            command_buffers,
+            per_frame_sync_primitives,
+            current_frame_index: 0,
+        })
+    }
+
+    fn is_device_suitable(
+        pdevice: vk::PhysicalDevice,
+        instance: &Instance,
+        queue_families: &[vk::QueueFamilyProperties],
+        is_preferred_device: bool,
+    ) -> bool {
+        // Check for required extensions (e.g., swapchain)
+        let required_extensions = [ash::extensions::khr::Swapchain::name()];
+        let available_extensions = unsafe {
+            instance.enumerate_device_extension_properties(pdevice)
+        }.unwrap_or_else(|_| Vec::new());
+
+        let mut all_extensions_supported = true;
+        for req_ext_name in required_extensions.iter() {
+            let found = available_extensions.iter().any(|ext| {
+                let ext_name = unsafe { CStr::from_ptr(ext.extension_name.as_ptr()) };
+                ext_name == *req_ext_name
+            });
+            if !found {
+                all_extensions_supported = false;
+                break;
+            }
+        }
+        if !all_extensions_supported {
+            return false;
+        }
+
+        // Check if we have at least one graphics queue
+        let has_graphics_queue = queue_families.iter().any(|qf| qf.queue_flags.contains(vk::QueueFlags::GRAPHICS));
+
+        // For now, we only check for graphics queue and extensions.
+        // Presentation support will be checked by find_queue_families.
+        // More checks can be added here (e.g., features, specific limits)
+
+        has_graphics_queue // && (is_preferred_device || true) // Allow non-preferred if it's suitable
+    }
+
+    fn find_queue_families(
+        instance: &Instance, // Not strictly needed here but might be for future surface checks
+        pdevice: vk::PhysicalDevice,
+        queue_families: &[vk::QueueFamilyProperties],
+    ) -> Option<(u32, u32)> {
+        let mut graphics_family_index = None;
+        // For now, assume graphics and present might be the same queue.
+        // Later, Wayland surface support check will be needed for present_family_index.
+        // For this initial setup, we'll simplify and assume a queue that supports graphics can also present.
+        // This will need to be refined when actual surface interaction is implemented.
+        let mut present_family_index = None;
+
+        for (i, queue_family) in queue_families.iter().enumerate() {
+            if queue_family.queue_flags.contains(vk::QueueFlags::GRAPHICS) {
+                graphics_family_index = Some(i as u32);
+                // Placeholder for present check - for now, use graphics queue if it exists
+                // In a real scenario, you'd check for surface support here:
+                // let surface_support = unsafe {
+                //     ash::extensions::khr::Surface::get_physical_device_surface_support(
+                //         instance, pdevice, i as u32, surface_khr // surface_khr would be an argument
+                //     ).unwrap_or(false)
+                // };
+                // if surface_support {
+                //    present_family_index = Some(i as u32);
+                // }
+                present_family_index = Some(i as u32); // Simplified for now
+            }
+
+            if graphics_family_index.is_some() && present_family_index.is_some() {
+                break;
+            }
+        }
+
+        if graphics_family_index.is_some() && present_family_index.is_some() {
+             graphics_family_index.zip(present_family_index)
+        } else {
+            None
+        }
+    }
+
+    // ANCHOR: Accessor Methods
+    pub fn entry(&self) -> &Entry {
+        &self.entry
+    }
+
+    pub fn instance(&self) -> &Instance { // Returns &ash::Instance
+        self.instance.as_ref()
+    }
+
+    pub fn instance_arc(&self) -> &Arc<Instance> { // Returns &Arc<ash::Instance>
+        &self.instance
+    }
+
+    pub fn physical_device(&self) -> vk::PhysicalDevice {
+        self.physical_device
+    }
+
+    pub fn device(&self) -> &Arc<ash::Device> { // Already returns &Arc<ash::Device>
+        &self.device
+    }
+
+    pub fn graphics_queue_family_index(&self) -> u32 {
+        self.graphics_queue_family_index
+    }
+
+    pub fn present_queue_family_index(&self) -> u32 {
+        self.present_queue_family_index
+    }
+
+    pub fn graphics_queue(&self) -> vk::Queue {
+        self.graphics_queue
+    }
+
+    pub fn present_queue(&self) -> vk::Queue {
+        self.present_queue
+    }
+
+    pub fn allocator(&self) -> Arc<std::sync::Mutex<vma::Allocator>> {
+        self.allocator.clone()
+    }
+
+    // Method to get current_frame_index, useful for NovaVulkanRenderer to select sync primitives
+    pub fn current_frame_index(&self) -> usize {
+        self.current_frame_index
+    }
+
+
+    // ANCHOR_EXT: Record and Submit Draw Commands
+    pub fn record_and_submit_draw_commands(
+        &mut self,
+        image_index: u32, // Acquired swapchain image index
+        // Assuming these are passed in; VulkanContext doesn't own them directly.
+        // In a fuller renderer, these might be members or retrieved differently.
+        swapchain_extent: vk::Extent2D,
+        render_pass_handle: vk::RenderPass,
+        framebuffer_handle: vk::Framebuffer, // Specific framebuffer for the image_index
+        graphics_pipeline_handle: vk::Pipeline,
+        pipeline_layout_handle: vk::PipelineLayout,
+        // New parameters for drawing a textured quad
+        vertex_buffer: vk::Buffer,
+        index_buffer: vk::Buffer,
+        index_count: u32,
+        descriptor_set: Option<vk::DescriptorSet>, // Optional, for texture
+    ) -> Result<(), String> {
+        let frame_sync_primitives = &self.per_frame_sync_primitives[self.current_frame_index];
+        let command_buffer = self.command_buffers[self.current_frame_index];
+
+        unsafe {
+            // ANCHOR_EXT_SUB: Wait for Fence
+            // Wait for the previous frame using this set of sync primitives to finish
+            self.device.wait_for_fences(
+                &[frame_sync_primitives.in_flight_fence],
+                true, // Wait for all fences
+                u64::MAX, // Timeout
+            ).map_err(|e| format!("Failed to wait for in_flight_fence: {}", e))?;
+
+            // Reset fence once we know the command buffer it's guarding is no longer in use
+            self.device.reset_fences(&[frame_sync_primitives.in_flight_fence])
+                .map_err(|e| format!("Failed to reset in_flight_fence: {}", e))?;
+
+            // ANCHOR_EXT_SUB: Reset and Begin Command Buffer
+            self.device.reset_command_buffer(command_buffer, vk::CommandBufferResetFlags::empty())
+                .map_err(|e| format!("Failed to reset command buffer: {}", e))?;
+
+            let begin_info = vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
+            self.device.begin_command_buffer(command_buffer, &begin_info)
+                .map_err(|e| format!("Failed to begin command buffer: {}", e))?;
+
+            // ANCHOR_EXT_SUB: Begin Render Pass
+            let clear_values = [vk::ClearValue {
+                color: vk::ClearColorValue {
+                    float32: [0.0, 0.0, 0.0, 1.0], // Black clear color
+                },
+            }];
+            let render_area = vk::Rect2D {
+                offset: vk::Offset2D { x: 0, y: 0 },
+                extent: swapchain_extent,
+            };
+            let render_pass_begin_info = vk::RenderPassBeginInfo::builder()
+                .render_pass(render_pass_handle)
+                .framebuffer(framebuffer_handle)
+                .render_area(render_area)
+                .clear_values(&clear_values);
+
+            self.device.cmd_begin_render_pass(
+                command_buffer,
+                &render_pass_begin_info,
+                vk::SubpassContents::INLINE,
+            );
+
+            // ANCHOR_EXT_SUB: Bind Pipeline
+            self.device.cmd_bind_pipeline(
+                command_buffer,
+                vk::PipelineBindPoint::GRAPHICS,
+                graphics_pipeline_handle,
+            );
+
+            // ANCHOR_EXT_SUB: Set Viewport & Scissor (Dynamic States)
+            let viewport = vk::Viewport::builder()
+                .x(0.0)
+                .y(0.0)
+                .width(swapchain_extent.width as f32)
+                .height(swapchain_extent.height as f32)
+                .min_depth(0.0)
+                .max_depth(1.0)
+                .build();
+            self.device.cmd_set_viewport(command_buffer, 0, &[viewport]);
+
+            let scissor = vk::Rect2D::builder()
+                .offset(vk::Offset2D { x: 0, y: 0 })
+                .extent(swapchain_extent)
+                .build();
+            self.device.cmd_set_scissor(command_buffer, 0, &[scissor]);
+
+            // ANCHOR_EXT_SUB: Bind Vertex and Index Buffers
+            let vertex_buffers = [vertex_buffer];
+            let offsets = [0_u64]; // Offset into the vertex buffer
+            self.device.cmd_bind_vertex_buffers(command_buffer, 0, &vertex_buffers, &offsets);
+            self.device.cmd_bind_index_buffer(command_buffer, index_buffer, 0, vk::IndexType::UINT16); // Assuming u16 indices
+
+            // ANCHOR_EXT_SUB: Bind Descriptor Sets (if provided)
+            if let Some(ds) = descriptor_set {
+                self.device.cmd_bind_descriptor_sets(
+                    command_buffer,
+                    vk::PipelineBindPoint::GRAPHICS,
+                    pipeline_layout_handle,
+                    0, // firstSet
+                    &[ds],
+                    &[], // No dynamic offsets
+                );
+            }
+
+            // ANCHOR_EXT_SUB: Draw Indexed Call
+            self.device.cmd_draw_indexed(command_buffer, index_count, 1, 0, 0, 0);
+
+            // ANCHOR_EXT_SUB: End Render Pass
+            self.device.cmd_end_render_pass(command_buffer);
+
+            // ANCHOR_EXT_SUB: End Command Buffer
+            self.device.end_command_buffer(command_buffer)
+                .map_err(|e| format!("Failed to end command buffer: {}", e))?;
+
+            // ANCHOR_EXT_SUB: Submit to Graphics Queue
+            let wait_semaphores = [frame_sync_primitives.image_available_semaphore];
+            let wait_stages = [vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT];
+            let signal_semaphores = [frame_sync_primitives.render_finished_semaphore];
+            let submit_command_buffers = [command_buffer];
+
+            let submit_info = vk::SubmitInfo::builder()
+                .wait_semaphores(&wait_semaphores)
+                .wait_dst_stage_mask(&wait_stages)
+                .command_buffers(&submit_command_buffers)
+                .signal_semaphores(&signal_semaphores)
+                .build();
+
+            self.device.queue_submit(
+                self.graphics_queue,
+                &[submit_info],
+                frame_sync_primitives.in_flight_fence, // Signal this fence when commands complete
+            ).map_err(|e| format!("Failed to submit to graphics queue: {}", e))?;
+        }
+        Ok(())
+    }
+
+    // Call this after successful submission and presentation, before starting the next frame.
+    pub fn advance_frame_index(&mut self) {
+        self.current_frame_index = (self.current_frame_index + 1) % MAX_FRAMES_IN_FLIGHT;
+    }
+}
+
+// ANCHOR: VulkanContext Drop Implementation
+impl Drop for VulkanContext {
+    fn drop(&mut self) {
+        println!("Dropping VulkanContext...");
+
+        // The resources are generally dropped in the reverse order of their declaration
+        // within the struct, due to Rust's RAII rules. Arc<T> and Mutex<T> also follow this,
+        // calling the Drop trait of their contained type when their reference count reaches zero
+        // or they go out of scope respectively.
+
+        // 1. `allocator: Arc<std::sync::Mutex<vma::Allocator>>`
+        //    When `VulkanContext` is dropped, this `Arc`'s count might decrement. If it's the last one,
+        //    the `Mutex` is dropped, and then the `vma::Allocator` is dropped.
+        //    `gpu_allocator::vulkan::Allocator` has its own `Drop` implementation that releases
+        //    all VMA resources. This needs the `ash::Device` and `ash::Instance` to be alive.
+        //    The declaration order in `VulkanContext` (device then allocator) means allocator is dropped first.
+        //    This is correct.
+        //    (No explicit call needed here; RAII handles it.)
+        //    println!("VMA Allocator will be dropped by RAII.");
+
+        // 2. `device: Arc<ash::Device>`
+        //    After the allocator (if any user of it is dropped), the `device` Arc may be dropped.
+        //    If this `VulkanContext` holds the last `Arc<ash::Device>`, then the `ash::Device`
+        //    itself is dropped. The `ash::Device`'s `Drop` trait calls `vkDestroyDevice`.
+        //    This needs the `ash::Instance` to be alive.
+        //    (No explicit call needed here; RAII handles it.)
+        //    println!("Logical Device will be dropped by RAII via Arc.");
+
+        // 3. `debug_messenger: Option<vk::DebugUtilsMessengerEXT>`
+        //    This must be destroyed before the instance.
+        //    It also needs the `debug_utils_loader` to be alive.
+        if let (Some(messenger), Some(loader)) = (self.debug_messenger.take(), self.debug_utils_loader.as_ref()) {
+            // `take()` the Option field to prevent potential double-free if drop was ever called multiple times
+            // (Rust ensures drop is called once, but good practice with manual cleanup patterns).
+            // `as_ref()` on loader is fine as it's only used for its function pointers.
+            unsafe {
+                loader.destroy_debug_utils_messenger(messenger, None);
+            }
+            println!("Vulkan debug messenger destroyed.");
+        }
+        // `debug_utils_loader` is Option<ash::extensions::ext::DebugUtils>. ash::extensions::ext::DebugUtils
+        // is a struct of function pointers loaded from the instance, it doesn't own resources itself.
+        // It will be dropped, but no specific cleanup call is needed for it.
+
+        // 4. `instance: Arc<Instance>`
+        //    The `Arc<ash::Instance>` is dropped last among these key components.
+        //    If this is the last Arc, its inner `ash::Instance`'s Drop trait calls `vkDestroyInstance`.
+        //    (No explicit call needed here; RAII handles it.)
+        //    println!("Vulkan Instance will be dropped by RAII via Arc.");
+
+        // `entry: Entry` is typically loaded and doesn't own Vulkan resources that need explicit cleanup.
+        // `physical_device` is a handle and doesn't need to be destroyed.
+        // Queues (`graphics_queue`, `present_queue`) are owned by the logical device and are cleaned up with it.
+
+        println!("VulkanContext dropped.");
+    }
+}

--- a/novade-system/src/renderers/vulkan/framebuffer.rs
+++ b/novade-system/src/renderers/vulkan/framebuffer.rs
@@ -1,0 +1,56 @@
+use ash::{vk, Device as AshDevice};
+use std::sync::Arc;
+
+// ANCHOR: VulkanFramebuffer Struct Definition
+pub struct VulkanFramebuffer {
+    device: Arc<AshDevice>,
+    framebuffer: vk::Framebuffer,
+}
+
+// ANCHOR: VulkanFramebuffer Implementation
+impl VulkanFramebuffer {
+    pub fn new(
+        device: Arc<AshDevice>,
+        render_pass: vk::RenderPass, // The render pass this framebuffer is compatible with
+        image_view: vk::ImageView,   // The image view to attach
+        extent: vk::Extent2D,        // Dimensions of the framebuffer
+    ) -> Result<Self, String> {
+
+        // ANCHOR_EXT: Framebuffer Create Info
+        let attachments = [image_view];
+        let framebuffer_create_info = vk::FramebufferCreateInfo::builder()
+            .render_pass(render_pass)
+            .attachments(&attachments)
+            .width(extent.width)
+            .height(extent.height)
+            .layers(1)
+            .build();
+
+        let framebuffer = unsafe {
+            device
+                .create_framebuffer(&framebuffer_create_info, None)
+                .map_err(|e| format!("Failed to create framebuffer: {}", e))?
+        };
+
+        // It might be useful to log creation, perhaps with extent or image_view handle
+        // println!("VulkanFramebuffer created for ImageView {:?} with extent {}x{}", image_view, extent.width, extent.height);
+        Ok(Self { device, framebuffer })
+    }
+
+    // ANCHOR: Accessor for vk::Framebuffer
+    pub fn handle(&self) -> vk::Framebuffer {
+        self.framebuffer
+    }
+}
+
+// ANCHOR: VulkanFramebuffer Drop Implementation
+impl Drop for VulkanFramebuffer {
+    fn drop(&mut self) {
+        unsafe {
+            self.device.destroy_framebuffer(self.framebuffer, None);
+        }
+        // To avoid spamming logs if many framebuffers are created/destroyed (e.g. per swapchain image)
+        // consider making this log conditional or less verbose.
+        // println!("VulkanFramebuffer dropped (handle: {:?}).", self.framebuffer);
+    }
+}

--- a/novade-system/src/renderers/vulkan/image.rs
+++ b/novade-system/src/renderers/vulkan/image.rs
@@ -1,0 +1,133 @@
+use ash::{vk, Device as AshDevice};
+use gpu_allocator::vulkan as vma;
+use gpu_allocator::MemoryUsage as GpuMemoryUsage;
+use std::sync::{Arc, Mutex};
+
+// ANCHOR: VulkanImage Struct Definition
+pub struct VulkanImage {
+    device: Arc<AshDevice>,
+    allocator: Arc<Mutex<vma::Allocator>>,
+    pub image: vk::Image, // Public for direct use in render pass attachments, descriptor updates, etc.
+    allocation: Option<vma::Allocation>, // Option to allow taking it in drop
+    pub extent: vk::Extent3D, // Public for info
+    pub format: vk::Format,   // Public for info (e.g., creating image views)
+    // current_layout: vk::ImageLayout, // Could be added if image tracks its own layout
+}
+
+// ANCHOR: VulkanImage Implementation
+impl VulkanImage {
+    pub fn new(
+        device: Arc<AshDevice>,
+        allocator: Arc<Mutex<vma::Allocator>>,
+        image_create_info: &vk::ImageCreateInfo, // Pass by reference as it can be large
+        memory_usage: GpuMemoryUsage,        // e.g., GpuOnly, CpuToGpu
+    ) -> Result<Self, String> {
+        if image_create_info.extent.width == 0 || image_create_info.extent.height == 0 || image_create_info.extent.depth == 0 {
+            return Err("Image extent dimensions cannot be zero.".to_string());
+        }
+        if image_create_info.mip_levels == 0 {
+            return Err("Image mip_levels cannot be zero.".to_string());
+        }
+        if image_create_info.array_layers == 0 {
+            return Err("Image array_layers cannot be zero.".to_string());
+        }
+
+        let allocation_create_info = vma::AllocationCreateInfo {
+            usage: memory_usage,
+            // flags, required_flags, preferred_flags, pool can be specified if needed
+            ..Default::default()
+        };
+
+        let (image, allocation) = unsafe {
+            allocator
+                .lock()
+                .map_err(|_| "Failed to lock allocator mutex for image creation".to_string())?
+                .create_image(image_create_info, &allocation_create_info)
+                .map_err(|e| format!("VMA failed to create image: {:?}", e))?
+        };
+
+        Ok(Self {
+            device,
+            allocator,
+            image,
+            allocation: Some(allocation),
+            extent: image_create_info.extent,
+            format: image_create_info.format,
+            // current_layout: image_create_info.initial_layout, // Store initial layout
+        })
+    }
+
+    // ANCHOR_EXT: create_image_view (Associated function or method)
+    // Making this an associated function for now, but could be a method on VulkanImage.
+    pub fn create_image_view(
+        device: &AshDevice, // Can take &Arc<AshDevice> too
+        image: vk::Image,
+        format: vk::Format,
+        aspect_flags: vk::ImageAspectFlags,
+        mip_levels: u32, // Pass mip_levels for the view
+    ) -> Result<vk::ImageView, String> {
+        let image_view_create_info = vk::ImageViewCreateInfo::builder()
+            .image(image)
+            .view_type(vk::ImageViewType::TYPE_2D) // Assuming 2D, make flexible if needed
+            .format(format)
+            .components(vk::ComponentMapping {
+                r: vk::ComponentSwizzle::IDENTITY,
+                g: vk::ComponentSwizzle::IDENTITY,
+                b: vk::ComponentSwizzle::IDENTITY,
+                a: vk::ComponentSwizzle::IDENTITY,
+            })
+            .subresource_range(vk::ImageSubresourceRange {
+                aspect_mask: aspect_flags,
+                base_mip_level: 0,
+                level_count: mip_levels,
+                base_array_layer: 0,
+                layer_count: 1, // Assuming 1 layer, make flexible if needed (e.g. for cube maps)
+            });
+
+        unsafe {
+            device.create_image_view(&image_view_create_info, None)
+        }.map_err(|e| format!("Failed to create image view: {}", e))
+    }
+
+    // ANCHOR: Accessors
+    pub fn handle(&self) -> vk::Image {
+        self.image
+    }
+
+    pub fn format(&self) -> vk::Format {
+        self.format
+    }
+
+    pub fn extent(&self) -> vk::Extent3D {
+        self.extent
+    }
+
+    // pub fn current_layout(&self) -> vk::ImageLayout {
+    //     self.current_layout
+    // }
+
+    // pub fn set_current_layout(&mut self, new_layout: vk::ImageLayout) {
+    //     self.current_layout = new_layout;
+    // }
+
+    pub fn allocation_info(&self) -> Option<&vma::AllocationInfo> {
+        self.allocation.as_ref().map(|a| a.info())
+    }
+}
+
+// ANCHOR: VulkanImage Drop Implementation
+impl Drop for VulkanImage {
+    fn drop(&mut self) {
+        if let Some(allocation) = self.allocation.take() {
+            //println!("Dropping VulkanImage: {:?}, Allocation: {:?}", self.image, allocation.info());
+            if let Ok(mut allocator_guard) = self.allocator.lock() {
+                unsafe {
+                    allocator_guard.destroy_image(self.image, allocation)
+                        .unwrap_or_else(|e| eprintln!("VMA failed to destroy image: {:?}", e));
+                }
+            } else {
+                eprintln!("VulkanImage::drop: Failed to lock allocator mutex. Image and allocation may leak.");
+            }
+        }
+    }
+}

--- a/novade-system/src/renderers/vulkan/mod.rs
+++ b/novade-system/src/renderers/vulkan/mod.rs
@@ -9,6 +9,25 @@ pub mod memory;
 pub mod dmabuf;
 pub mod texture_pipeline; // New
 pub mod command_buffer;   // New
+pub mod render_pass;      // Added for render pass
+pub mod framebuffer;      // Added for framebuffer
+pub mod shader;           // Added for shader modules
+pub mod pipeline;         // Added for graphics pipelines
+pub mod sync;             // Added for synchronization primitives
+pub mod renderer;         // Added for NovaVulkanRenderer
+pub mod buffer;           // Added for VMA-backed VulkanBuffer
+pub mod image;            // Added for VMA-backed VulkanImage
+
+pub use self::context::VulkanContext; // Assuming context.rs defines VulkanContext
+pub use self::swapchain::VulkanSwapchain; // Added for the new VulkanSwapchain struct
+pub use self::render_pass::VulkanRenderPass; // Added for VulkanRenderPass
+pub use self::framebuffer::VulkanFramebuffer; // Added for VulkanFramebuffer
+pub use self::shader::VulkanShaderModule; // Added for VulkanShaderModule
+pub use self::pipeline::VulkanPipeline; // Added for VulkanPipeline
+pub use self::sync::FrameSyncPrimitives; // Added for FrameSyncPrimitives
+pub use self.renderer::NovaVulkanRenderer; // Added for NovaVulkanRenderer
+pub use self::buffer::VulkanBuffer; // Added for VMA-backed VulkanBuffer
+pub use self::image::VulkanImage;   // Added for VMA-backed VulkanImage
 
 use crate::renderer_interface::RendererInterface;
 use novade_core::types::geometry::Size2D;

--- a/novade-system/src/renderers/vulkan/pipeline.rs
+++ b/novade-system/src/renderers/vulkan/pipeline.rs
@@ -1,0 +1,217 @@
+use ash::{vk, Device as AshDevice};
+use std::sync::Arc;
+use super::shader::VulkanShaderModule; // Assuming VulkanShaderModule is in super::shader
+
+// ANCHOR: VulkanPipeline Struct Definition
+pub struct VulkanPipeline {
+    device: Arc<AshDevice>,
+    pipeline_layout: vk::PipelineLayout,
+    // descriptor_set_layouts: Vec<vk::DescriptorSetLayout>, // For future use
+    pipeline: vk::Pipeline,
+}
+
+// ANCHOR: VulkanPipeline Implementation
+impl VulkanPipeline {
+    pub fn new(
+        device: Arc<AshDevice>,
+        render_pass: vk::RenderPass,
+        swapchain_extent: vk::Extent2D,
+        vert_shader_module: &VulkanShaderModule,
+        frag_shader_module: &VulkanShaderModule,
+        texture_descriptor_set_layout: vk::DescriptorSetLayout, // Added
+    ) -> Result<Self, String> {
+
+        // ANCHOR_EXT: Shader Stages
+        let vert_shader_stage_info = vk::PipelineShaderStageCreateInfo::builder()
+            .stage(vk::ShaderStageFlags::VERTEX)
+            .module(vert_shader_module.handle())
+            .name(std::ffi::CStr::from_bytes_with_nul(b"main\0").unwrap()); // Entry point
+
+        let frag_shader_stage_info = vk::PipelineShaderStageCreateInfo::builder()
+            .stage(vk::ShaderStageFlags::FRAGMENT)
+            .module(frag_shader_module.handle())
+            .name(std::ffi::CStr::from_bytes_with_nul(b"main\0").unwrap()); // Entry point
+
+        let shader_stages = [vert_shader_stage_info.build(), frag_shader_stage_info.build()];
+
+        // ANCHOR_EXT: Vertex Input State (for textured quad)
+        // vec2 pos, vec2 texcoord
+        const STRIDE: u32 = (2 + 2) * std::mem::size_of::<f32>() as u32;
+
+        let binding_descriptions = [vk::VertexInputBindingDescription::builder()
+            .binding(0)
+            .stride(STRIDE)
+            .input_rate(vk::VertexInputRate::VERTEX)
+            .build()];
+
+        let attribute_descriptions = [
+            // Position (vec2)
+            vk::VertexInputAttributeDescription::builder()
+                .location(0) // layout (location = 0) in shader
+                .binding(0)
+                .format(vk::Format::R32G32_SFLOAT)
+                .offset(0)
+                .build(),
+            // Texture Coordinate (vec2)
+            vk::VertexInputAttributeDescription::builder()
+                .location(1) // layout (location = 1) in shader
+                .binding(0)
+                .format(vk::Format::R32G32_SFLOAT)
+                .offset((2 * std::mem::size_of::<f32>()) as u32) // Offset after position
+                .build(),
+        ];
+
+        let vertex_input_info = vk::PipelineVertexInputStateCreateInfo::builder()
+            .vertex_binding_descriptions(&binding_descriptions)
+            .vertex_attribute_descriptions(&attribute_descriptions);
+
+        // ANCHOR_EXT: Input Assembly State
+        let input_assembly = vk::PipelineInputAssemblyStateCreateInfo::builder()
+            .topology(vk::PrimitiveTopology::TRIANGLE_LIST)
+            .primitive_restart_enable(false);
+
+        // ANCHOR_EXT: Viewport and Scissor
+        let viewport = vk::Viewport::builder()
+            .x(0.0)
+            .y(0.0)
+            .width(swapchain_extent.width as f32)
+            .height(swapchain_extent.height as f32)
+            .min_depth(0.0)
+            .max_depth(1.0)
+            .build();
+
+        let scissor = vk::Rect2D::builder()
+            .offset(vk::Offset2D { x: 0, y: 0 })
+            .extent(swapchain_extent)
+            .build();
+
+        // ANCHOR_EXT: Viewport State
+        // If not using dynamic viewport/scissor, this is how you set them:
+        // let viewport_state = vk::PipelineViewportStateCreateInfo::builder()
+        //     .viewports(std::slice::from_ref(&viewport))
+        //     .scissors(std::slice::from_ref(&scissor));
+        // However, we'll use dynamic states for viewport and scissor for more flexibility.
+        let viewport_state = vk::PipelineViewportStateCreateInfo::builder()
+            .viewport_count(1) // Dynamic state will provide actual viewport
+            .scissor_count(1); // Dynamic state will provide actual scissor
+
+
+        // ANCHOR_EXT: Rasterization State
+        let rasterizer = vk::PipelineRasterizationStateCreateInfo::builder()
+            .depth_clamp_enable(false)
+            .rasterizer_discard_enable(false)
+            .polygon_mode(vk::PolygonMode::FILL)
+            .line_width(1.0)
+            .cull_mode(vk::CullModeFlags::BACK)
+            .front_face(vk::FrontFace::CLOCKWISE) // Assuming standard winding order
+            .depth_bias_enable(false);
+
+        // ANCHOR_EXT: Multisample State
+        let multisampling = vk::PipelineMultisampleStateCreateInfo::builder()
+            .sample_shading_enable(false)
+            .rasterization_samples(vk::SampleCountFlags::TYPE_1);
+            // .min_sample_shading(1.0) // Optional
+            // .sample_mask(&[]) // Optional
+            // .alpha_to_coverage_enable(false) // Optional
+            // .alpha_to_one_enable(false); // Optional
+
+        // ANCHOR_EXT: Depth/Stencil State (Disabled for now)
+        let depth_stencil_state = vk::PipelineDepthStencilStateCreateInfo::builder()
+            .depth_test_enable(false)
+            .depth_write_enable(false)
+            .depth_compare_op(vk::CompareOp::LESS_OR_EQUAL) // Common default
+            .depth_bounds_test_enable(false)
+            .stencil_test_enable(false);
+            // .min_depth_bounds(0.0) // Optional
+            // .max_depth_bounds(1.0); // Optional
+
+        // ANCHOR_EXT: Color Blend Attachment State (Opaque for now)
+        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::builder()
+            .color_write_mask(vk::ColorComponentFlags::RGBA)
+            .blend_enable(false) // No blending
+            // Example for alpha blending (if blend_enable(true)):
+            // .src_color_blend_factor(vk::BlendFactor::SRC_ALPHA)
+            // .dst_color_blend_factor(vk::BlendFactor::ONE_MINUS_SRC_ALPHA)
+            // .color_blend_op(vk::BlendOp::ADD)
+            // .src_alpha_blend_factor(vk::BlendFactor::ONE)
+            // .dst_alpha_blend_factor(vk::BlendFactor::ZERO)
+            // .alpha_blend_op(vk::BlendOp::ADD)
+            .build();
+
+        // ANCHOR_EXT: Color Blend State
+        let color_blending = vk::PipelineColorBlendStateCreateInfo::builder()
+            .logic_op_enable(false)
+            .logic_op(vk::LogicOp::COPY) // Optional
+            .attachments(std::slice::from_ref(&color_blend_attachment))
+            .blend_constants([0.0, 0.0, 0.0, 0.0]); // Optional
+
+        // ANCHOR_EXT: Pipeline Layout
+        let set_layouts = [texture_descriptor_set_layout];
+        let pipeline_layout_create_info = vk::PipelineLayoutCreateInfo::builder()
+            .set_layouts(&set_layouts) // Use the passed-in descriptor set layout
+            .push_constant_ranges(&[]); // No push constants yet
+
+        let pipeline_layout = unsafe {
+            device.create_pipeline_layout(&pipeline_layout_create_info, None)
+        }.map_err(|e| format!("Failed to create pipeline layout: {}", e))?;
+
+        // ANCHOR_EXT: Dynamic States
+        let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
+        let dynamic_state_info = vk::PipelineDynamicStateCreateInfo::builder()
+            .dynamic_states(&dynamic_states);
+
+        // ANCHOR_EXT: Graphics Pipeline Create Info
+        let pipeline_info = vk::GraphicsPipelineCreateInfo::builder()
+            .stages(&shader_stages)
+            .vertex_input_state(&vertex_input_info)
+            .input_assembly_state(&input_assembly)
+            .viewport_state(&viewport_state) // Viewport and scissor set via dynamic states
+            .rasterization_state(&rasterizer)
+            .multisample_state(&multisampling)
+            .depth_stencil_state(&depth_stencil_state) // Or None if completely disabled
+            .color_blend_state(&color_blending)
+            .dynamic_state(&dynamic_state_info) // Specify dynamic states
+            .layout(pipeline_layout)
+            .render_pass(render_pass)
+            .subpass(0) // Index of the subpass where this pipeline will be used
+            .base_pipeline_handle(vk::Pipeline::null()) // Optional: for pipeline derivatives
+            .base_pipeline_index(-1); // Optional
+
+        let pipelines = unsafe {
+            device.create_graphics_pipelines(vk::PipelineCache::null(), std::slice::from_ref(&pipeline_info.build()), None)
+        }.map_err(|e| {
+            // Cleanup pipeline layout if pipeline creation fails
+            unsafe { device.destroy_pipeline_layout(pipeline_layout, None); }
+            format!("Failed to create graphics pipeline: {:?}", e) // Using {:?} for result type
+        })?;
+
+        let pipeline = pipelines[0]; // We only create one pipeline
+
+        Ok(Self {
+            device,
+            pipeline_layout,
+            pipeline,
+        })
+    }
+
+    // ANCHOR: Accessors
+    pub fn handle(&self) -> vk::Pipeline {
+        self.pipeline
+    }
+
+    pub fn layout_handle(&self) -> vk::PipelineLayout {
+        self.pipeline_layout
+    }
+}
+
+// ANCHOR: VulkanPipeline Drop Implementation
+impl Drop for VulkanPipeline {
+    fn drop(&mut self) {
+        unsafe {
+            self.device.destroy_pipeline(self.pipeline, None);
+            // Destroy descriptor set layouts here if they were created and stored
+            self.device.destroy_pipeline_layout(self.pipeline_layout, None);
+        }
+        // println!("VulkanPipeline (handle: {:?}, layout: {:?}) dropped.", self.pipeline, self.pipeline_layout);
+    }
+}

--- a/novade-system/src/renderers/vulkan/render_pass.rs
+++ b/novade-system/src/renderers/vulkan/render_pass.rs
@@ -1,0 +1,82 @@
+use ash::{vk, Device as AshDevice};
+use std::sync::Arc;
+
+// ANCHOR: VulkanRenderPass Struct Definition
+pub struct VulkanRenderPass {
+    device: Arc<AshDevice>,
+    render_pass: vk::RenderPass,
+}
+
+// ANCHOR: VulkanRenderPass Implementation
+impl VulkanRenderPass {
+    pub fn new(device: Arc<AshDevice>, color_format: vk::Format) -> Result<Self, String> {
+        // ANCHOR_EXT: Attachment Description
+        let color_attachment = vk::AttachmentDescription::builder()
+            .format(color_format)
+            .samples(vk::SampleCountFlags::TYPE_1)
+            .load_op(vk::AttachmentLoadOp::CLEAR)
+            .store_op(vk::AttachmentStoreOp::STORE)
+            .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
+            .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
+            .initial_layout(vk::ImageLayout::UNDEFINED)
+            .final_layout(vk::ImageLayout::PRESENT_SRC_KHR) // For direct presentation
+            .build();
+
+        // ANCHOR_EXT: Color Attachment Reference
+        let color_attachment_ref = vk::AttachmentReference::builder()
+            .attachment(0) // Index in the pAttachments array of RenderPassCreateInfo
+            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
+            .build();
+
+        // ANCHOR_EXT: Subpass Description
+        let subpass = vk::SubpassDescription::builder()
+            .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS)
+            .color_attachments(std::slice::from_ref(&color_attachment_ref))
+            // No depth/stencil, input, resolve, or preserve attachments for this simple pass
+            .build();
+
+        // ANCHOR_EXT: Subpass Dependency
+        // This dependency ensures that the render pass waits for the image to be available
+        // (e.g., from the swapchain) before writing to it, and that writing is finished
+        // before the image is presented.
+        let dependency = vk::SubpassDependency::builder()
+            .src_subpass(vk::SUBPASS_EXTERNAL) // Implicit subpass before render pass
+            .dst_subpass(0) // Our subpass (index 0)
+            .src_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT)
+            .src_access_mask(vk::AccessFlags::empty()) // No access required from previous stage for this simple case
+            .dst_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT)
+            .dst_access_mask(vk::AccessFlags::COLOR_ATTACHMENT_WRITE)
+            .build();
+
+        // ANCHOR_EXT: Render Pass Create Info
+        let render_pass_create_info = vk::RenderPassCreateInfo::builder()
+            .attachments(std::slice::from_ref(&color_attachment))
+            .subpasses(std::slice::from_ref(&subpass))
+            .dependencies(std::slice::from_ref(&dependency))
+            .build();
+
+        let render_pass = unsafe {
+            device
+                .create_render_pass(&render_pass_create_info, None)
+                .map_err(|e| format!("Failed to create render pass: {}", e))?
+        };
+
+        println!("VulkanRenderPass created successfully.");
+        Ok(Self { device, render_pass })
+    }
+
+    // ANCHOR: Accessor for vk::RenderPass
+    pub fn handle(&self) -> vk::RenderPass {
+        self.render_pass
+    }
+}
+
+// ANCHOR: VulkanRenderPass Drop Implementation
+impl Drop for VulkanRenderPass {
+    fn drop(&mut self) {
+        unsafe {
+            self.device.destroy_render_pass(self.render_pass, None);
+        }
+        println!("VulkanRenderPass dropped.");
+    }
+}

--- a/novade-system/src/renderers/vulkan/renderer.rs
+++ b/novade-system/src/renderers/vulkan/renderer.rs
@@ -1,0 +1,592 @@
+use ash::{vk, Device as AshDevice, Instance as AshInstance};
+use std::sync::Arc;
+use std::ffi::c_void;
+use raw_window_handle::{WaylandDisplayHandle, WaylandWindowHandle, HasRawWindowHandle, HasRawDisplayHandle, RawWindowHandle, RawDisplayHandle};
+
+// Import necessary modules from the current Vulkan renderer structure
+use super::context::VulkanContext;
+use super::swapchain::VulkanSwapchain;
+use super::render_pass::VulkanRenderPass;
+use super::framebuffer::VulkanFramebuffer;
+use super::pipeline::VulkanPipeline;
+use super::shader::VulkanShaderModule;
+use super::sync::FrameSyncPrimitives;
+
+use gpu_allocator::MemoryUsage as GpuMemoryUsage; // For VMA
+
+// Import necessary modules from the current Vulkan renderer structure
+use super::context::VulkanContext;
+use super::swapchain::VulkanSwapchain;
+use super::render_pass::VulkanRenderPass;
+use super::framebuffer::VulkanFramebuffer;
+use super::pipeline::VulkanPipeline;
+use super::shader::VulkanShaderModule;
+use super::sync::FrameSyncPrimitives;
+// Import the new VMA-backed Buffer and Image structs
+use super::buffer::VulkanBuffer;
+use super::image::VulkanImage;
+// Import command buffer helpers if they are to be used from here
+use super::command_buffer;
+
+
+// ANCHOR: NovaVulkanRenderer Struct Definition
+pub struct NovaVulkanRenderer {
+    pub vulkan_context: Arc<VulkanContext>,
+    swapchain: Option<VulkanSwapchain>,
+    render_pass: Option<VulkanRenderPass>,
+    framebuffers: Vec<VulkanFramebuffer>,
+
+    textured_quad_pipeline: Option<VulkanPipeline>,
+
+    // Use VMA-backed VulkanBuffer and VulkanImage
+    vertex_buffer: Option<VulkanBuffer>,
+    index_buffer: Option<VulkanBuffer>,
+
+    texture_descriptor_set_layout: Option<vk::DescriptorSetLayout>,
+    texture_descriptor_pool: Option<vk::DescriptorPool>,
+    // One descriptor set per frame in flight, or per swapchain image, if texture can change
+    // For a single placeholder texture, one might be enough if updated carefully,
+    // but per-frame is safer with multiple frames in flight.
+    texture_descriptor_sets: Vec<vk::DescriptorSet>,
+
+    // Placeholder texture and sampler
+    placeholder_texture: Option<VulkanImage>,
+    placeholder_texture_view: Option<vk::ImageView>, // ImageView is separate from VulkanImage
+    placeholder_sampler: Option<vk::Sampler>,
+
+    // Placeholder for actual Wayland window handles from Smithay
+    // These would be properly obtained and managed in a real integration.
+    // We need a way to provide these to VulkanSwapchain::new
+    // For now, we store raw pointers and create dummy handles.
+    wayland_display_ptr: *mut c_void,
+    wayland_surface_ptr: *mut c_void,
+
+    // Smithay window handle abstraction (not used yet, but for future)
+    // window_handle: raw_window_handle::WaylandWindowHandle,
+
+    // Tracks which set of sync primitives (from VulkanContext) to use for the current frame.
+    // This ensures that we use a different semaphore/fence set for each concurrent frame.
+    // VulkanContext.current_frame_index is the one that indexes into its arrays.
+    // NovaVulkanRenderer.current_frame_cycle_index is used to pick which sync primitive set.
+    // This can be the same as VulkanContext.current_frame_index if context manages cycling directly.
+    // For clarity, let's assume NovaVulkanRenderer tells context which sync objects to use implicitly via context.current_frame_index
+}
+
+// ANCHOR: NovaVulkanRenderer Implementation
+impl NovaVulkanRenderer {
+    pub fn new(
+        // These raw pointers are placeholders for what Smithay would provide.
+        // Smithay's DisplayHandle and WlSurface would be used to get RawDisplayHandle and RawWindowHandle.
+        wayland_display_handle_ptr: *mut c_void,
+        wayland_surface_handle_ptr: *mut c_void,
+    ) -> Result<Self, String> {
+        if wayland_display_handle_ptr.is_null() || wayland_surface_handle_ptr.is_null() {
+            println!("NovaVulkanRenderer::new: Initializing with null Wayland display/surface handles. Surface creation is expected to fail.");
+        }
+        let context = VulkanContext::new().map_err(|e| format!("Failed to create VulkanContext: {}", e))?;
+
+        Ok(Self {
+            vulkan_context: Arc::new(context),
+            swapchain: None,
+            render_pass: None,
+            framebuffers: Vec::new(),
+            textured_quad_pipeline: None,
+            vertex_buffer: None,
+            index_buffer: None,
+            texture_descriptor_set_layout: None,
+            texture_descriptor_pool: None,
+            texture_descriptor_sets: Vec::new(),
+            placeholder_texture: None,
+            placeholder_sampler: None,
+            wayland_display_ptr: wayland_display_handle_ptr,
+            wayland_surface_ptr: wayland_surface_handle_ptr,
+        })
+    }
+
+    pub fn init_swapchain(&mut self, width: u32, height: u32) -> Result<(), String> {
+        let device = self.vulkan_context.device();
+        // Ensure device is idle before changing critical resources like swapchain
+        unsafe { device.device_wait_idle().map_err(|e| e.to_string())? };
+
+        // 1. Cleanup old swapchain-dependent resources
+        self.cleanup_swapchain_dependent_resources();
+
+        let old_swapchain_khr = self.swapchain.take().map(|sc| {
+            let khr = sc.swapchain;
+            drop(sc);
+            khr
+        });
+        println!("Old swapchain resources cleaned up.");
+
+        // 2. Create new VulkanSwapchain
+        let new_swapchain = VulkanSwapchain::new(
+            &self.vulkan_context,
+            &self,
+            width, height,
+            old_swapchain_khr,
+        ).map_err(|e| format!("Failed to create VulkanSwapchain: {}", e))?;
+        let swapchain_format = new_swapchain.format();
+        let swapchain_extent = new_swapchain.extent();
+        self.swapchain = Some(new_swapchain);
+        println!("New swapchain created.");
+
+        // 3. Create VulkanRenderPass
+        let new_render_pass = VulkanRenderPass::new(
+            device.clone(),
+            swapchain_format,
+        ).map_err(|e| format!("Failed to create VulkanRenderPass: {}", e))?;
+        self.render_pass = Some(new_render_pass);
+        println!("New render pass created.");
+
+        // 4. Create VulkanFramebuffers
+        self.framebuffers = self.swapchain.as_ref().unwrap().image_views()
+            .iter()
+            .map(|iv| {
+                VulkanFramebuffer::new(
+                    device.clone(),
+                    self.render_pass.as_ref().unwrap().handle(),
+                    *iv,
+                    swapchain_extent,
+                )
+            })
+            .collect::<Result<Vec<_>, String>>()
+            .map_err(|e| format!("Failed to create framebuffers: {}", e))?;
+        println!("Framebuffers created (count: {}).", self.framebuffers.len());
+
+        // 5. Create Descriptor Set Layout (for texture sampler)
+        self.create_texture_descriptor_set_layout()?;
+
+        // 6. Create Graphics Pipeline
+        let vert_shader_path = "novade-system/assets/shaders/textured.vert.spv";
+        let frag_shader_path = "novade-system/assets/shaders/textured.frag.spv";
+        let vert_shader_module = VulkanShaderModule::new_from_file(device.clone(), vert_shader_path)?;
+        let frag_shader_module = VulkanShaderModule::new_from_file(device.clone(), frag_shader_path)?;
+
+        let new_pipeline = VulkanPipeline::new(
+            device.clone(),
+            self.render_pass.as_ref().unwrap().handle(),
+            swapchain_extent,
+            &vert_shader_module,
+            &frag_shader_module,
+            self.texture_descriptor_set_layout.unwrap(), // Safe to unwrap after create_..._layout
+        ).map_err(|e| format!("Failed to create graphics pipeline: {}", e))?;
+        self.textured_quad_pipeline = Some(new_pipeline);
+        // Shaders can be dropped now as they are compiled into the pipeline
+        drop(vert_shader_module);
+        drop(frag_shader_module);
+        println!("Textured quad graphics pipeline created.");
+
+        // 7. Create Vertex and Index Buffers
+        self.create_vertex_buffer()?;
+        self.create_index_buffer()?;
+
+        // 8. Create Placeholder Texture and Sampler
+        self.create_placeholder_texture_and_sampler()?;
+
+        // 9. Create Descriptor Pool
+        let pool_sizes = [vk::DescriptorPoolSize::builder()
+            .ty(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
+            .descriptor_count(1) // Only one descriptor set needed for the single placeholder texture
+            .build()];
+        let pool_info = vk::DescriptorPoolCreateInfo::builder()
+            .pool_sizes(&pool_sizes)
+            .max_sets(1) // Max number of descriptor sets that can be allocated
+            .flags(vk::DescriptorPoolCreateFlags::empty()); // Or FREE_DESCRIPTOR_SET_BIT if sets can be freed individually
+
+        self.texture_descriptor_pool = Some(unsafe {
+            device.create_descriptor_pool(&pool_info, None)
+        }.map_err(|e| format!("Failed to create descriptor pool: {}", e))?);
+        println!("Texture descriptor pool created.");
+
+        // 10. Allocate Descriptor Sets
+        let layouts_to_alloc = [self.texture_descriptor_set_layout.unwrap()]; // Safe to unwrap
+        let alloc_info = vk::DescriptorSetAllocateInfo::builder()
+            .descriptor_pool(self.texture_descriptor_pool.unwrap()) // Safe
+            .set_layouts(&layouts_to_alloc);
+
+        let descriptor_sets_vec = unsafe {
+            device.allocate_descriptor_sets(&alloc_info)
+        }.map_err(|e| format!("Failed to allocate descriptor sets: {}", e))?;
+        self.texture_descriptor_sets = descriptor_sets_vec; // Should be Vec<vk::DescriptorSet>
+        println!("Texture descriptor set allocated: {:?}", self.texture_descriptor_sets[0]);
+
+        // 11. Update Descriptor Sets
+        let image_info = vk::DescriptorImageInfo::builder()
+            .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL) // Assuming texture is in this layout
+            .image_view(self.placeholder_texture.as_ref().unwrap().view) // Safe
+            .sampler(self.placeholder_sampler.unwrap()) // Safe
+            .build();
+        let image_infos = [image_info];
+
+        let descriptor_write = vk::WriteDescriptorSet::builder()
+            .dst_set(self.texture_descriptor_sets[0])
+            .dst_binding(0) // Binding 0 in shader
+            .dst_array_element(0)
+            .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
+            .image_info(&image_infos)
+            // .buffer_info(&[]) // For buffer descriptors
+            // .texel_buffer_view(&[]) // For texel buffer views
+            .build();
+
+        unsafe { device.update_descriptor_sets(std::slice::from_ref(&descriptor_write), &[]) };
+        println!("Descriptor set updated to point to placeholder texture/sampler.");
+
+        Ok(())
+    }
+
+    fn cleanup_swapchain_dependent_resources(&mut self) {
+        let device = self.vulkan_context.device();
+        // Framebuffers depend on render pass and image views (managed by swapchain).
+        self.framebuffers.clear(); // Drops VulkanFramebuffer, destroying vk::Framebuffer
+        if let Some(rp) = self.render_pass.take() { drop(rp); }
+        if let Some(pipeline) = self.textured_quad_pipeline.take() { drop(pipeline); }
+
+        // Cleanup descriptor-related resources that might be (re)created with swapchain
+        // or if they depend on the number of swapchain images (e.g. one set per image).
+        // Here, we assume they are generally recreated.
+        if let Some(pool) = self.texture_descriptor_pool.take() {
+            // Descriptor sets are freed when the pool is destroyed
+            unsafe { device.destroy_descriptor_pool(pool, None); }
+            self.texture_descriptor_sets.clear();
+        }
+        if let Some(layout) = self.texture_descriptor_set_layout.take() {
+            unsafe { device.destroy_descriptor_set_layout(layout, None); }
+        }
+        // Sampler and texture are more general, but might be recreated if their properties depend on swapchain.
+        // For now, placeholder_sampler and placeholder_texture are handled in main drop.
+        // If they were swapchain-dependent, they'd be cleaned here too.
+    }
+
+    fn create_texture_descriptor_set_layout(&mut self) -> Result<(), String> {
+        let bindings = [vk::DescriptorSetLayoutBinding::builder()
+            .binding(0) // layout (set=0, binding=0) in fragment shader
+            .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
+            .descriptor_count(1)
+            .stage_flags(vk::ShaderStageFlags::FRAGMENT)
+            .build()];
+
+        let layout_info = vk::DescriptorSetLayoutCreateInfo::builder().bindings(&bindings);
+        self.texture_descriptor_set_layout = Some(unsafe {
+            self.vulkan_context.device().create_descriptor_set_layout(&layout_info, None)
+        }.map_err(|e| format!("Failed to create descriptor set layout: {}", e))?);
+        println!("Texture descriptor set layout created.");
+        Ok(())
+    }
+
+    // ANCHOR_EXT: create_vertex_buffer
+    fn create_vertex_buffer(&mut self) -> Result<(), String> {
+        let vertices_data: [f32; 16] = [
+            // pos         texcoord
+            -0.5, -0.5,   0.0, 0.0, // Vertex 0: Top-left
+             0.5, -0.5,   1.0, 0.0, // Vertex 1: Top-right
+             0.5,  0.5,   1.0, 1.0, // Vertex 2: Bottom-right
+            -0.5,  0.5,   0.0, 1.0, // Vertex 3: Bottom-left
+        ];
+        let size = std::mem::size_of_val(&vertices_data) as vk::DeviceSize;
+
+        // For now, using simplified placeholder buffer creation.
+        // A real implementation would use a staging buffer for device-local memory.
+        let buffer = VulkanBuffer::new_placeholder(
+            self.vulkan_context.device().clone(),
+            size,
+            vk::BufferUsageFlags::VERTEX_BUFFER, // No TRANSFER_DST if not using staging
+        ).map_err(|e| format!("Failed to create vertex buffer: {}", e))?;
+
+        // If not using staging, need to map and copy data (requires host-visible memory for buffer)
+        // This is highly dependent on the memory type chosen by new_placeholder, which is currently bad.
+        // For now, we assume new_placeholder creates a buffer we can theoretically use.
+        // Proper implementation needs VMA and memory mapping.
+        // unsafe {
+        //     let memory = self.vulkan_context.device().map_memory(buffer.memory, 0, size, vk::MemoryMapFlags::empty())?;
+        //     std::ptr::copy_nonoverlapping(vertices_data.as_ptr() as *const c_void, memory, size as usize);
+        //     self.vulkan_context.device().unmap_memory(buffer.memory);
+        // }
+        self.vertex_buffer = Some(buffer);
+        println!("Vertex buffer created (placeholder). Size: {}", size);
+        Ok(())
+    }
+
+    // ANCHOR_EXT: create_index_buffer
+    fn create_index_buffer(&mut self) -> Result<(), String> {
+        let indices_data: [u16; 6] = [0, 1, 2, 2, 3, 0];
+        let size = std::mem::size_of_val(&indices_data) as vk::DeviceSize;
+
+        let buffer = VulkanBuffer::new_placeholder(
+            self.vulkan_context.device().clone(),
+            size,
+            vk::BufferUsageFlags::INDEX_BUFFER,
+        ).map_err(|e| format!("Failed to create index buffer: {}", e))?;
+        // Similar memory mapping story as vertex buffer for non-staging.
+        self.index_buffer = Some(buffer);
+        println!("Index buffer created (placeholder). Size: {}", size);
+        Ok(())
+    }
+
+    // ANCHOR_EXT: create_placeholder_texture_and_sampler
+    fn create_placeholder_texture_and_sampler(&mut self) -> Result<(), String> {
+        let device = self.vulkan_context.device();
+        // Create a 2x2 checkerboard texture (RGBA)
+        let width = 2;
+        let height = 2;
+        let format = vk::Format::R8G8B8A8_UNORM; // Or SRGB if color space handled correctly
+
+        let texture = VulkanImage::new_placeholder_texture(device.clone(), width, height, format)?;
+        // Placeholder: Fill texture with data (e.g., checkerboard)
+        // This would involve:
+        // 1. Creating a staging buffer.
+        // 2. Copying pixel data to staging buffer.
+        // 3. Transitioning image layout to TRANSFER_DST_OPTIMAL.
+        // 4. Copying from staging buffer to image.
+        // 5. Transitioning image layout to SHADER_READ_ONLY_OPTIMAL.
+        // For now, the texture is created but not filled with data.
+        println!("Placeholder texture created (but not filled with data). View: {:?}", texture.view);
+        self.placeholder_texture = Some(texture);
+
+        // Create a sampler
+        let sampler_info = vk::SamplerCreateInfo::builder()
+            .mag_filter(vk::Filter::LINEAR)
+            .min_filter(vk::Filter::LINEAR)
+            .address_mode_u(vk::SamplerAddressMode::REPEAT)
+            .address_mode_v(vk::SamplerAddressMode::REPEAT)
+            .address_mode_w(vk::SamplerAddressMode::REPEAT)
+            .anisotropy_enable(false) // Enable if physical device feature is available and desired
+            // .max_anisotropy(16.0)
+            .border_color(vk::BorderColor::INT_OPAQUE_BLACK)
+            .unnormalized_coordinates(false)
+            .compare_enable(false)
+            .compare_op(vk::CompareOp::ALWAYS)
+            .mipmap_mode(vk::SamplerMipmapMode::LINEAR)
+            .mip_lod_bias(0.0)
+            .min_lod(0.0)
+            .max_lod(0.0); // Set max_lod > 0 if using mipmaps
+
+        self.placeholder_sampler = Some(unsafe {
+            device.create_sampler(&sampler_info, None)
+        }.map_err(|e| format!("Failed to create sampler: {}", e))?);
+        println!("Placeholder sampler created: {:?}", self.placeholder_sampler.unwrap());
+        Ok(())
+    }
+
+    // ANCHOR_EXT: render_frame
+    pub fn render_frame(&mut self) -> Result<(), String> {
+        let device = self.vulkan_context.device(); // Arc<AshDevice>
+
+        // Ensure all necessary components are initialized
+        let swapchain = self.swapchain.as_ref().ok_or_else(|| "Swapchain not initialized".to_string())?;
+        let render_pass = self.render_pass.as_ref().ok_or_else(|| "RenderPass not initialized".to_string())?;
+        let pipeline = self.textured_quad_pipeline.as_ref().ok_or_else(|| "Pipeline not initialized".to_string())?;
+        let vb = self.vertex_buffer.as_ref().ok_or_else(|| "Vertex buffer not initialized".to_string())?;
+        let ib = self.index_buffer.as_ref().ok_or_else(|| "Index buffer not initialized".to_string())?;
+        // Assuming 6 indices for a quad
+        let index_count = 6;
+        let current_descriptor_set = self.texture_descriptor_sets.get(0) // Assuming one DS for now
+            .ok_or_else(|| "Descriptor set not available".to_string())?;
+
+
+        // Use sync primitives from VulkanContext based on its internal current_frame_index
+        let sync_primitives = &self.vulkan_context.per_frame_sync_primitives[self.vulkan_context.current_frame_index()];
+
+        // 1. Acquire Next Swapchain Image
+        let acquire_result = unsafe {
+            swapchain.swapchain_loader.acquire_next_image(
+                swapchain.swapchain,
+                u64::MAX, // Timeout
+                sync_primitives.image_available_semaphore,
+                vk::Fence::null(), // Not using a fence for acquisition itself here
+            )
+        };
+
+        let (image_index, _is_suboptimal) = match acquire_result {
+            Ok((idx, suboptimal)) => (idx, suboptimal),
+            Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => {
+                // Handle swapchain recreation
+                println!("Swapchain out of date during acquire, needs recreation.");
+                // self.recreate_swapchain(width, height)?; // Assuming width/height are available
+                return Err("Swapchain out of date, implement recreation.".to_string()); // Placeholder
+            }
+            Err(e) => return Err(format!("Failed to acquire swapchain image: {}", e)),
+        };
+
+        // 2. Record and Submit Command Buffer
+        // Ensure VulkanContext's current_frame_index is correct for command buffer and its own sync primitives
+        // NovaVulkanRenderer does not need its own current_frame_index if VulkanContext manages its array indexing.
+
+        let framebuffer_handle = self.framebuffers[image_index as usize].handle();
+
+        self.vulkan_context.record_and_submit_draw_commands(
+            image_index,
+            swapchain.extent(),
+            render_pass.handle(),
+            framebuffer_handle,
+            pipeline.handle(),
+            pipeline.layout_handle(),
+            vb.buffer,
+            ib.buffer,
+            index_count,
+            Some(*current_descriptor_set),
+        )?;
+
+        // 3. Present Image
+        let present_info = vk::PresentInfoKHR::builder()
+            .wait_semaphores(std::slice::from_ref(&sync_primitives.render_finished_semaphore))
+            .swapchains(std::slice::from_ref(&swapchain.swapchain))
+            .image_indices(std::slice::from_ref(&image_index));
+
+        let present_result = unsafe {
+            swapchain.swapchain_loader.queue_present(self.vulkan_context.present_queue(), &present_info)
+        };
+
+        match present_result {
+            Ok(suboptimal) if suboptimal => {
+                println!("Swapchain suboptimal during present, should recreate soon.");
+                // self.recreate_swapchain(width, height)?; // Placeholder
+            }
+            Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => {
+                println!("Swapchain out of date during present, needs recreation.");
+                // self.recreate_swapchain(width, height)?; // Placeholder
+                return Err("Swapchain out of date, implement recreation.".to_string()); // Placeholder
+            }
+            Err(e) => return Err(format!("Failed to present swapchain image: {}", e)),
+            _ => {} // Success
+        }
+
+        // 4. Advance to next frame's sync primitives and command buffer
+        self.vulkan_context.advance_frame_index();
+
+        Ok(())
+    }
+
+    // Placeholder RawWindowHandle provider using stored pointers
+    // This is unsafe and for temporary use only.
+    // A proper implementation would get these from Smithay's WlSurface.
+    fn get_raw_window_handle(&self) -> RawWindowHandle {
+        let mut wlh = WaylandWindowHandle::empty();
+        wlh.surface = self.wayland_surface_ptr;
+        // wlh.display = self.wayland_display_ptr; // WaylandWindowHandle doesn't have display, DisplayHandle does
+        RawWindowHandle::Wayland(wlh)
+    }
+    fn get_raw_display_handle(&self) -> RawDisplayHandle {
+        let mut dh = WaylandDisplayHandle::empty();
+        dh.display = self.wayland_display_ptr;
+        RawDisplayHandle::Wayland(dh)
+    }
+
+}
+
+// ANCHOR: NovaVulkanRenderer Drop Implementation
+impl Drop for NovaVulkanRenderer {
+    fn drop(&mut self) {
+        // Important: Ensure device is idle before destroying resources,
+        // especially if some resources (like pipelines, render passes)
+        // are used by commands that might still be executing.
+        // The VulkanContext itself doesn't have a device_wait_idle in its drop,
+        // so the top-level renderer should handle this.
+        if let Ok(_) = unsafe { self.vulkan_context.device().device_wait_idle() } {
+             println!("NovaVulkanRenderer: Device idle on drop.");
+        } else {
+            eprintln!("NovaVulkanRenderer: Failed to wait for device idle on drop.");
+        }
+
+
+        // Explicitly drop resources in correct order.
+        // Framebuffers depend on render pass and image views (managed by swapchain).
+        // Pipeline depends on render pass and descriptor set layouts.
+        // Swapchain holds image views.
+
+        // 1. Destroy pipeline
+        if let Some(pipeline) = self.textured_quad_pipeline.take() {
+            // VulkanPipeline's Drop will handle vkDestroyPipeline and vkDestroyPipelineLayout
+            drop(pipeline);
+            println!("Textured quad pipeline dropped.");
+        }
+
+        // 2. Destroy descriptor pool (which frees descriptor sets)
+        if let Some(pool) = self.texture_descriptor_pool.take() {
+            unsafe { self.vulkan_context.device().destroy_descriptor_pool(pool, None); }
+            println!("Texture descriptor pool dropped.");
+        }
+        // Descriptor sets are freed with the pool.
+        self.texture_descriptor_sets.clear();
+
+        // 3. Destroy descriptor set layout
+        if let Some(layout) = self.texture_descriptor_set_layout.take() {
+            unsafe { self.vulkan_context.device().destroy_descriptor_set_layout(layout, None); }
+            println!("Texture descriptor set layout dropped.");
+        }
+
+        // 4. Destroy placeholder texture resources
+        if let Some(sampler) = self.placeholder_sampler.take() {
+            unsafe { self.vulkan_context.device().destroy_sampler(sampler, None); }
+            println!("Placeholder sampler dropped.");
+        }
+        // Destroy placeholder texture resources
+        if let Some(view) = self.placeholder_texture_view.take() {
+            unsafe { self.vulkan_context.device().destroy_image_view(view, None); }
+            println!("Placeholder texture view dropped.");
+        }
+        if let Some(sampler) = self.placeholder_sampler.take() {
+            unsafe { self.vulkan_context.device().destroy_sampler(sampler, None); }
+            println!("Placeholder sampler dropped.");
+        }
+        if let Some(image) = self.placeholder_texture.take() {
+            // VulkanImage's Drop will handle cleanup via VMA
+            drop(image);
+            println!("Placeholder texture dropped (VMA).");
+        }
+
+        // 5. Destroy vertex and index buffers
+        // VulkanBuffer's Drop will handle cleanup via VMA
+        if let Some(buffer) = self.vertex_buffer.take() {
+            drop(buffer);
+            println!("Vertex buffer dropped (VMA).");
+        }
+        if let Some(buffer) = self.index_buffer.take() {
+            drop(buffer);
+            println!("Index buffer dropped (VMA).");
+        }
+
+        // 6. Framebuffers (Vec will drop its contents, calling VulkanFramebuffer::drop)
+        // Make sure framebuffers are dropped before render_pass and swapchain (image_views)
+        self.framebuffers.clear();
+        println!("Framebuffers cleared and dropped.");
+
+        // 7. RenderPass
+        if let Some(rp) = self.render_pass.take() {
+            drop(rp);
+            println!("RenderPass dropped.");
+        }
+
+        // 8. Swapchain (VulkanSwapchain::drop will handle its image views, swapchain, surface)
+        if let Some(sc) = self.swapchain.take() {
+            drop(sc);
+            println!("Swapchain dropped.");
+        }
+
+        // 9. VulkanContext is an Arc, it will drop when its ref count is zero.
+        // Its own Drop impl handles its resources (command pool, sync primitives, device, instance etc.)
+        // We might want to ensure that `vulkan_context` is the last thing to be dropped,
+        // or at least that its device is alive for all the cleanup above.
+        // Arc ensures this as long as we hold `vulkan_context` and pass clones of `Arc<Device>` to sub-structs.
+        println!("NovaVulkanRenderer dropped. VulkanContext will be dropped if this was the last Arc ref.");
+    }
+}
+
+// Implement HasRawWindowHandle and HasRawDisplayHandle for NovaVulkanRenderer using placeholders
+// This is VERY UNSAFE and only for temporary testing until proper Smithay integration.
+// A real solution would involve getting these handles from Smithay's WlSurface and DisplayHandle.
+unsafe impl HasRawWindowHandle for NovaVulkanRenderer {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        let mut handle = WaylandWindowHandle::empty();
+        handle.surface = self.wayland_surface_ptr;
+        // handle.display = self.wayland_display_ptr; // Not part of WaylandWindowHandle
+        RawWindowHandle::Wayland(handle)
+    }
+}
+
+unsafe impl HasRawDisplayHandle for NovaVulkanRenderer {
+    fn raw_display_handle(&self) -> RawDisplayHandle {
+        let mut handle = WaylandDisplayHandle::empty();
+        handle.display = self.wayland_display_ptr;
+        RawDisplayHandle::Wayland(handle)
+    }
+}

--- a/novade-system/src/renderers/vulkan/shader.rs
+++ b/novade-system/src/renderers/vulkan/shader.rs
@@ -1,0 +1,91 @@
+use ash::{util::read_spv, vk, Device as AshDevice};
+use std::fs::File;
+use std::io::Cursor;
+use std::path::Path;
+use std::sync::Arc;
+
+// ANCHOR: VulkanShaderModule Struct Definition
+pub struct VulkanShaderModule {
+    device: Arc<AshDevice>,
+    shader_module: vk::ShaderModule,
+}
+
+// ANCHOR: VulkanShaderModule Implementation
+impl VulkanShaderModule {
+    // ANCHOR_EXT: new from SPIR-V code
+    pub fn new_from_bytes(device: Arc<AshDevice>, spirv_code: &[u8]) -> Result<Self, String> {
+        // The SPIR-V code is expected to be a slice of bytes, which ash::util::read_spv
+        // can convert to a slice of u32.
+        // Ensure the byte slice length is a multiple of 4.
+        if spirv_code.len() % 4 != 0 {
+            return Err(format!(
+                "SPIR-V code length ({}) is not a multiple of 4.",
+                spirv_code.len()
+            ));
+        }
+
+        // The `read_spv` function expects an `std::io::Read` trait object.
+        // We can use a `Cursor` to wrap the byte slice.
+        // The code must be aligned to a 4-byte boundary.
+        // `ash::util::read_spv` handles converting &[u8] to Vec<u32> if needed.
+        // However, vk::ShaderModuleCreateInfo expects *const u32.
+        // A common way is to ensure the input Vec<u8> is properly aligned and then cast its pointer.
+        // Or, copy to Vec<u32>. Let's ensure our Vec<u8> becomes Vec<u32>.
+
+        let mut cursor = Cursor::new(spirv_code);
+        let code_u32 = read_spv(&mut cursor)
+            .map_err(|e| format!("Failed to read SPIR-V bytes into u32 words: {}", e))?;
+
+        let shader_module_create_info = vk::ShaderModuleCreateInfo::builder()
+            .code(&code_u32); // pCode expects a slice of u32
+
+        let shader_module = unsafe {
+            device
+                .create_shader_module(&shader_module_create_info, None)
+                .map_err(|e| format!("Failed to create shader module: {}", e))?
+        };
+
+        Ok(Self { device, shader_module })
+    }
+
+    // ANCHOR_EXT: new from file path
+    pub fn new_from_file(device: Arc<AshDevice>, path_str: &str) -> Result<Self, String> {
+        let path = Path::new(path_str);
+        if !path.exists() {
+            return Err(format!("Shader file not found: {}", path_str));
+        }
+
+        let spirv_bytes = std::fs::read(path)
+            .map_err(|e| format!("Failed to read shader file {}: {}", path_str, e))?;
+
+        Self::new_from_bytes(device, &spirv_bytes)
+    }
+
+    // ANCHOR: Accessor for vk::ShaderModule
+    pub fn handle(&self) -> vk::ShaderModule {
+        self.shader_module
+    }
+}
+
+// ANCHOR: VulkanShaderModule Drop Implementation
+impl Drop for VulkanShaderModule {
+    fn drop(&mut self) {
+        unsafe {
+            self.device.destroy_shader_module(self.shader_module, None);
+        }
+        // println!("VulkanShaderModule (handle: {:?}) dropped.", self.shader_module);
+    }
+}
+
+// ANCHOR: Helper function to load SPIR-V (kept outside for general use if needed, or can be made private static method)
+// This function is essentially duplicated by `new_from_file`'s internal logic now.
+// It could be removed if `new_from_file` is the preferred public API for file loading.
+// For now, keeping it as per original plan.
+pub fn load_spirv_file(path_str: &str) -> Result<Vec<u8>, String> {
+    let path = Path::new(path_str);
+    if !path.exists() {
+        return Err(format!("Shader file not found: {}", path_str));
+    }
+    std::fs::read(path)
+        .map_err(|e| format!("Failed to read shader file {}: {}", path_str, e))
+}

--- a/novade-system/src/renderers/vulkan/swapchain.rs
+++ b/novade-system/src/renderers/vulkan/swapchain.rs
@@ -1,171 +1,321 @@
-// novade-system/src/renderers/vulkan/swapchain.rs
-use ash::extensions::khr::Swapchain as SwapchainLoader;
-use ash::vk;
-use super::device::QueueFamilyIndices; // Assuming this path is correct
+use ash::{vk, Instance as AshInstance, Device as AshDevice};
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use std::sync::Arc;
 
+// Assuming VulkanContext is in super::context. This might need adjustment
+// if VulkanContext is not directly accessible or if a more abstract interface is preferred.
+use super::context::VulkanContext;
+
+// ANCHOR: SwapchainSupportDetails Struct Definition
+#[derive(Clone, Debug)]
 pub struct SwapchainSupportDetails {
     pub capabilities: vk::SurfaceCapabilitiesKHR,
     pub formats: Vec<vk::SurfaceFormatKHR>,
     pub present_modes: Vec<vk::PresentModeKHR>,
 }
 
-pub fn query_swapchain_support(
-    physical_device: vk::PhysicalDevice,
-    surface_loader: &ash::extensions::khr::Surface,
-    surface: vk::SurfaceKHR,
-) -> Result<SwapchainSupportDetails, String> {
-    unsafe {
-        let capabilities = surface_loader
-            .get_physical_device_surface_capabilities(physical_device, surface)
-            .map_err(|e| format!("Failed to get surface capabilities: {}", e))?;
-        let formats = surface_loader
-            .get_physical_device_surface_formats(physical_device, surface)
-            .map_err(|e| format!("Failed to get surface formats: {}", e))?;
-        let present_modes = surface_loader
-            .get_physical_device_surface_present_modes(physical_device, surface)
-            .map_err(|e| format!("Failed to get surface present modes: {}", e))?;
-        Ok(SwapchainSupportDetails {
-            capabilities,
-            formats,
-            present_modes,
+// ANCHOR: VulkanSwapchain Struct Definition
+pub struct VulkanSwapchain {
+    // Loaders - obtained from VulkanContext or created here if appropriate
+    surface_loader: ash::extensions::khr::Surface,
+    swapchain_loader: ash::extensions::khr::Swapchain,
+
+    pub surface: vk::SurfaceKHR,
+    pub swapchain: vk::SwapchainKHR,
+    pub images: Vec<vk::Image>,
+    pub image_views: Vec<vk::ImageView>,
+    pub format: vk::Format,
+    pub extent: vk::Extent2D,
+
+    // Keep a reference to the device for cleanup of image views and swapchain
+    device: Arc<AshDevice>,
+    // Keep a reference to the instance for cleanup of surface (if surface_loader is instance-level)
+    // Or, if surface_loader is entry-level, then entry might be needed.
+    // ash::extensions::khr::Surface is new(&entry, &instance). So instance is needed.
+    instance_ref: Arc<AshInstance>, // Keep a reference to instance for surface cleanup
+}
+
+// ANCHOR: VulkanSwapchain Implementation
+impl VulkanSwapchain {
+    pub fn new(
+        context: &VulkanContext, // Provides instance, device, physical_device, entry
+        window_handle: &impl HasRawWindowHandle,
+        window_width: u32,
+        window_height: u32,
+        old_swapchain_khr: Option<vk::SwapchainKHR>,
+    ) -> Result<Self, String> {
+
+        // ANCHOR_EXT: Surface Creation
+        let surface_loader = ash::extensions::khr::Surface::new(context.entry(), context.instance());
+        let surface = unsafe {
+            ash_window::create_surface(
+                context.entry(),
+                context.instance(),
+                window_handle.raw_window_handle(),
+                None,
+            )
+        }.map_err(|e| format!("Failed to create Vulkan surface: {}", e))?;
+
+        // Check for Wayland surface support on the physical device's queue family
+        // This check was simplified in context.rs, but should be more robust here or in context.
+        // For now, assume the queue family selected in VulkanContext supports presentation to this surface.
+        let present_support = unsafe {
+            surface_loader.get_physical_device_surface_support(
+                context.physical_device(),
+                context.present_queue_family_index(), // Assuming present_queue_family_index is correct for this surface
+                surface,
+            )
+        }.unwrap_or(false);
+
+        if !present_support {
+            // Cleanup surface before erroring
+            unsafe { surface_loader.destroy_surface(surface, None); }
+            return Err(format!(
+                "Physical device queue family {} does not support presentation to this surface.",
+                context.present_queue_family_index()
+            ));
+        }
+
+        // ANCHOR_EXT: Query Swapchain Support
+        let support_details = Self::query_swapchain_support(
+            context.instance(),
+            &surface_loader,
+            context.physical_device(),
+            surface,
+        )?;
+
+        // ANCHOR_EXT: Choose Swapchain Settings
+        let surface_format = Self::choose_surface_format(&support_details.formats);
+        let present_mode = Self::choose_present_mode(&support_details.present_modes);
+        let extent = Self::choose_swap_extent(&support_details.capabilities, window_width, window_height);
+
+        let mut image_count = support_details.capabilities.min_image_count + 1;
+        if support_details.capabilities.max_image_count > 0 && image_count > support_details.capabilities.max_image_count {
+            image_count = support_details.capabilities.max_image_count;
+        }
+
+        // ANCHOR_EXT: Swapchain Creation
+        let swapchain_loader = ash::extensions::khr::Swapchain::new(context.instance(), context.device().as_ref());
+
+        let mut create_info = vk::SwapchainCreateInfoKHR::builder()
+            .surface(surface)
+            .min_image_count(image_count)
+            .image_format(surface_format.format)
+            .image_color_space(surface_format.color_space)
+            .image_extent(extent)
+            .image_array_layers(1)
+            .image_usage(vk::ImageUsageFlags::COLOR_ATTACHMENT); // Add other usages if needed (e.g., TRANSFER_DST)
+
+        let queue_family_indices = [
+            context.graphics_queue_family_index(),
+            context.present_queue_family_index(),
+        ];
+
+        if context.graphics_queue_family_index() != context.present_queue_family_index() {
+            create_info = create_info
+                .image_sharing_mode(vk::SharingMode::CONCURRENT)
+                .queue_family_indices(&queue_family_indices);
+        } else {
+            create_info = create_info.image_sharing_mode(vk::SharingMode::EXCLUSIVE);
+        }
+
+        create_info = create_info
+            .pre_transform(support_details.capabilities.current_transform)
+            .composite_alpha(vk::CompositeAlphaFlagsKHR::OPAQUE) // Or choose from capabilities
+            .present_mode(present_mode)
+            .clipped(true)
+            .old_swapchain(old_swapchain_khr.unwrap_or_else(vk::SwapchainKHR::null));
+
+        let swapchain = unsafe {
+            swapchain_loader.create_swapchain(&create_info, None)
+        }.map_err(|e| {
+            // Cleanup surface if swapchain creation fails
+            unsafe { surface_loader.destroy_surface(surface, None); }
+            format!("Failed to create swapchain: {}", e)
+        })?;
+
+        // ANCHOR_EXT: Retrieve Swapchain Images
+        let images = unsafe {
+            swapchain_loader.get_swapchain_images(swapchain)
+        }.map_err(|e| {
+            // Cleanup swapchain and surface if image retrieval fails
+            unsafe {
+                swapchain_loader.destroy_swapchain(swapchain, None);
+                surface_loader.destroy_surface(surface, None);
+            }
+            format!("Failed to get swapchain images: {}", e)
+        })?;
+
+        // ANCHOR_EXT: Create Image Views
+        let image_views = Self::create_image_views(context.device().as_ref(), &images, surface_format.format)?;
+
+        Ok(Self {
+            surface_loader,
+            swapchain_loader,
+            surface,
+            swapchain,
+            images,
+            image_views,
+            format: surface_format.format,
+            extent,
+            device: context.device().clone(), // Clone the Arc for shared ownership
+            instance_ref: context.instance_arc(), // Store Arc<Instance>
         })
     }
-}
 
-fn choose_swap_surface_format(available_formats: &[vk::SurfaceFormatKHR]) -> vk::SurfaceFormatKHR {
-    available_formats
-        .iter()
-        .cloned()
-        .find(|format| {
-            format.format == vk::Format::B8G8R8A8_SRGB // Or R8G8B8A8_SRGB
-                && format.color_space == vk::ColorSpaceKHR::SRGB_NONLINEAR
-        })
-        .unwrap_or_else(|| available_formats[0])
-}
-
-fn choose_swap_present_mode(available_present_modes: &[vk::PresentModeKHR]) -> vk::PresentModeKHR {
-    // Prefer Mailbox for low latency, FIFO is guaranteed fallback
-    if available_present_modes.contains(&vk::PresentModeKHR::MAILBOX) {
-        vk::PresentModeKHR::MAILBOX
-    } else {
-        vk::PresentModeKHR::FIFO // Guaranteed to be available
+    // ANCHOR: Accessors
+    pub fn format(&self) -> vk::Format {
+        self.format
     }
-}
 
-fn choose_swap_extent(capabilities: &vk::SurfaceCapabilitiesKHR, actual_width: u32, actual_height: u32) -> vk::Extent2D {
-    if capabilities.current_extent.width != u32::MAX {
-        capabilities.current_extent
-    } else {
-        vk::Extent2D {
-            width: actual_width.clamp(
-                capabilities.min_image_extent.width,
-                capabilities.max_image_extent.width,
-            ),
-            height: actual_height.clamp(
-                capabilities.min_image_extent.height,
-                capabilities.max_image_extent.height,
-            ),
+    pub fn extent(&self) -> vk::Extent2D {
+        self.extent
+    }
+
+    pub fn image_views(&self) -> &Vec<vk::ImageView> {
+        &self.image_views
+    }
+
+    // ANCHOR: Query Swapchain Support Helper
+    fn query_swapchain_support(
+        instance_ash: &AshInstance, // Renamed to avoid conflict with instance_ref field
+        surface_loader: &ash::extensions::khr::Surface,
+        physical_device: vk::PhysicalDevice,
+        surface: vk::SurfaceKHR,
+    ) -> Result<SwapchainSupportDetails, String> {
+        unsafe {
+            let capabilities = surface_loader
+                .get_physical_device_surface_capabilities(physical_device, surface)
+                .map_err(|e| format!("Failed to get surface capabilities: {}", e))?;
+
+            let formats = surface_loader
+                .get_physical_device_surface_formats(physical_device, surface)
+                .map_err(|e| format!("Failed to get surface formats: {}", e))?;
+
+            let present_modes = surface_loader
+                .get_physical_device_surface_present_modes(physical_device, surface)
+                .map_err(|e| format!("Failed to get surface present modes: {}", e))?;
+
+            if formats.is_empty() || present_modes.is_empty() {
+                return Err("No surface formats or present modes found for the physical device and surface.".to_string());
+            }
+
+            Ok(SwapchainSupportDetails {
+                capabilities,
+                formats,
+                present_modes,
+            })
         }
     }
-}
 
-pub fn create_swapchain(
-    instance: &ash::Instance, // Needed for SwapchainLoader
-    device: &ash::Device,
-    physical_device: vk::PhysicalDevice,
-    surface_loader: &ash::extensions::khr::Surface,
-    surface: vk::SurfaceKHR,
-    queue_family_indices: &QueueFamilyIndices,
-    window_width: u32, // Current window width
-    window_height: u32, // Current window height
-    old_swapchain: Option<vk::SwapchainKHR>, // For recreation
-) -> Result<(vk::SwapchainKHR, vk::Format, vk::Extent2D, Vec<vk::Image>), String> {
-    let support_details = query_swapchain_support(physical_device, surface_loader, surface)?;
-
-    let surface_format = choose_swap_surface_format(&support_details.formats);
-    let present_mode = choose_swap_present_mode(&support_details.present_modes);
-    let extent = choose_swap_extent(&support_details.capabilities, window_width, window_height);
-
-    let mut image_count = support_details.capabilities.min_image_count + 1;
-    if support_details.capabilities.max_image_count > 0 && image_count > support_details.capabilities.max_image_count {
-        image_count = support_details.capabilities.max_image_count;
+    // ANCHOR: Choose Surface Format Helper
+    fn choose_surface_format(
+        available_formats: &[vk::SurfaceFormatKHR],
+    ) -> vk::SurfaceFormatKHR {
+        available_formats
+            .iter()
+            .find(|format| {
+                format.format == vk::Format::B8G8R8A8_SRGB
+                    && format.color_space == vk::ColorSpaceKHR::SRGB_NONLINEAR
+            })
+            .cloned()
+            .unwrap_or_else(|| {
+                // Log this choice, as it's a fallback
+                println!("Warning: Desired format B8G8R8A8_SRGB with SRGB_NONLINEAR not found. Using first available: {:?}", available_formats[0]);
+                available_formats[0]
+            })
     }
 
-    let mut create_info = vk::SwapchainCreateInfoKHR::builder()
-        .surface(surface)
-        .min_image_count(image_count)
-        .image_format(surface_format.format)
-        .image_color_space(surface_format.color_space)
-        .image_extent(extent)
-        .image_array_layers(1)
-        .image_usage(vk::ImageUsageFlags::COLOR_ATTACHMENT | vk::ImageUsageFlags::TRANSFER_DST) // TRANSFER_DST for potential clear or post-processing blit
-        .pre_transform(support_details.capabilities.current_transform)
-        .composite_alpha(vk::CompositeAlphaFlagsKHR::OPAQUE) // Or choose based on capabilities
-        .present_mode(present_mode)
-        .clipped(true); // Performance improvement
-
-    let indices = [
-        queue_family_indices.graphics_family.unwrap(),
-        queue_family_indices.present_family.unwrap(),
-    ];
-
-    if queue_family_indices.graphics_family != queue_family_indices.present_family {
-        create_info = create_info
-            .image_sharing_mode(vk::SharingMode::CONCURRENT)
-            .queue_family_indices(&indices);
-    } else {
-        create_info = create_info.image_sharing_mode(vk::SharingMode::EXCLUSIVE);
+    // ANCHOR: Choose Present Mode Helper
+    fn choose_present_mode(
+        available_present_modes: &[vk::PresentModeKHR],
+    ) -> vk::PresentModeKHR {
+        if available_present_modes.contains(&vk::PresentModeKHR::MAILBOX) {
+            vk::PresentModeKHR::MAILBOX
+        } else {
+            // FIFO is guaranteed to be available according to the Vulkan specification.
+            vk::PresentModeKHR::FIFO
+        }
     }
 
-    if let Some(old) = old_swapchain {
-        create_info = create_info.old_swapchain(old);
-    }
-
-    let swapchain_loader = SwapchainLoader::new(instance, device);
-    let swapchain = unsafe {
-        swapchain_loader
-            .create_swapchain(&create_info, None)
-            .map_err(|e| format!("Failed to create swapchain: {}", e))?
-    };
-
-    let images = unsafe {
-        swapchain_loader.get_swapchain_images(swapchain)
-        .map_err(|e| format!("Failed to get swapchain images: {}", e))?
-    };
-
-    Ok((swapchain, surface_format.format, extent, images))
-}
-
-pub fn create_image_views(
-    device: &ash::Device,
-    images: &[vk::Image],
-    format: vk::Format,
-) -> Result<Vec<vk::ImageView>, String> {
-    images
-        .iter()
-        .map(|&image| {
-            let create_info = vk::ImageViewCreateInfo::builder()
-                .image(image)
-                .view_type(vk::ImageViewType::TYPE_2D)
-                .format(format)
-                .components(vk::ComponentMapping {
-                    r: vk::ComponentSwizzle::IDENTITY,
-                    g: vk::ComponentSwizzle::IDENTITY,
-                    b: vk::ComponentSwizzle::IDENTITY,
-                    a: vk::ComponentSwizzle::IDENTITY,
-                })
-                .subresource_range(vk::ImageSubresourceRange {
-                    aspect_mask: vk::ImageAspectFlags::COLOR,
-                    base_mip_level: 0,
-                    level_count: 1,
-                    base_array_layer: 0,
-                    layer_count: 1,
-                });
-            unsafe {
-                device
-                    .create_image_view(&create_info, None)
-                    .map_err(|e| format!("Failed to create image view: {}", e))
+    // ANCHOR: Choose Swap Extent Helper
+    fn choose_swap_extent(
+        capabilities: &vk::SurfaceCapabilitiesKHR,
+        window_width: u32,
+        window_height: u32,
+    ) -> vk::Extent2D {
+        if capabilities.current_extent.width != u32::MAX { // u32::max indicates dynamic size
+            capabilities.current_extent
+        } else {
+            vk::Extent2D {
+                width: window_width.clamp(
+                    capabilities.min_image_extent.width,
+                    capabilities.max_image_extent.width,
+                ),
+                height: window_height.clamp(
+                    capabilities.min_image_extent.height,
+                    capabilities.max_image_extent.height,
+                ),
             }
-        })
-        .collect()
+        }
+    }
+
+    // ANCHOR: Create Image Views Helper
+    fn create_image_views(
+        device: &AshDevice,
+        images: &[vk::Image],
+        format: vk::Format,
+    ) -> Result<Vec<vk::ImageView>, String> {
+        images
+            .iter()
+            .map(|&image| {
+                let create_info = vk::ImageViewCreateInfo::builder()
+                    .image(image)
+                    .view_type(vk::ImageViewType::TYPE_2D)
+                    .format(format)
+                    .components(vk::ComponentMapping {
+                        r: vk::ComponentSwizzle::IDENTITY,
+                        g: vk::ComponentSwizzle::IDENTITY,
+                        b: vk::ComponentSwizzle::IDENTITY,
+                        a: vk::ComponentSwizzle::IDENTITY,
+                    })
+                    .subresource_range(vk::ImageSubresourceRange {
+                        aspect_mask: vk::ImageAspectFlags::COLOR,
+                        base_mip_level: 0,
+                        level_count: 1,
+                        base_array_layer: 0,
+                        layer_count: 1,
+                    });
+                unsafe {
+                    device.create_image_view(&create_info, None)
+                }.map_err(|e| format!("Failed to create image view: {}", e))
+            })
+            .collect()
+    }
+}
+
+// ANCHOR: VulkanSwapchain Drop Implementation
+impl Drop for VulkanSwapchain {
+    fn drop(&mut self) {
+        unsafe {
+            println!("Dropping VulkanSwapchain...");
+            for image_view in self.image_views.drain(..) { // drain to empty the vec
+                self.device.destroy_image_view(image_view, None);
+            }
+            println!("Swapchain image views destroyed (count: {}).", self.images.len());
+
+            // Swapchain must be destroyed before the surface
+            self.swapchain_loader.destroy_swapchain(self.swapchain, None);
+            println!("Swapchain destroyed.");
+
+            // Surface is destroyed after the swapchain
+            self.surface_loader.destroy_surface(self.surface, None);
+            println!("Surface destroyed.");
+            // The device and instance_ref (Arc<AshDevice> and Arc<AshInstance>)
+            // will be dropped automatically by RAII when VulkanSwapchain goes out of scope.
+            // Their respective Drop impls will handle vkDestroyDevice and vkDestroyInstance if this
+            // was the last reference.
+            println!("VulkanSwapchain dropped.");
+        }
+    }
 }

--- a/novade-system/src/renderers/vulkan/sync.rs
+++ b/novade-system/src/renderers/vulkan/sync.rs
@@ -1,0 +1,65 @@
+use ash::{vk, Device as AshDevice};
+use std::sync::Arc;
+
+// ANCHOR: FrameSyncPrimitives Struct Definition
+pub struct FrameSyncPrimitives {
+    device: Arc<AshDevice>,
+    pub image_available_semaphore: vk::Semaphore,
+    pub render_finished_semaphore: vk::Semaphore,
+    pub in_flight_fence: vk::Fence,
+}
+
+// ANCHOR: FrameSyncPrimitives Implementation
+impl FrameSyncPrimitives {
+    pub fn new(device: Arc<AshDevice>) -> Result<Self, String> {
+        let semaphore_create_info = vk::SemaphoreCreateInfo::builder();
+        // No flags needed for basic semaphores
+
+        let image_available_semaphore = unsafe {
+            device
+                .create_semaphore(&semaphore_create_info, None)
+                .map_err(|e| format!("Failed to create image_available_semaphore: {}", e))?
+        };
+
+        let render_finished_semaphore = unsafe {
+            device
+                .create_semaphore(&semaphore_create_info, None)
+                .map_err(|e| format!("Failed to create render_finished_semaphore: {}", e))?
+        };
+
+        // Create fence in signaled state for the first frame to avoid deadlock
+        // if we wait on it before the first submission.
+        // However, typical frame loops wait then reset, so starting unsignaled is also common.
+        // For a MAX_FRAMES_IN_FLIGHT loop, fences are usually associated with a specific frame index's
+        // previous submission. If we always wait then submit, starting unsignaled is fine.
+        // Let's start unsignaled, as typical render loops will wait for the *previous* use of this fence.
+        let fence_create_info = vk::FenceCreateInfo::builder();
+            // .flags(vk::FenceCreateFlags::SIGNALED); // Only if needed for specific first-frame logic
+
+        let in_flight_fence = unsafe {
+            device
+                .create_fence(&fence_create_info, None)
+                .map_err(|e| format!("Failed to create in_flight_fence: {}", e))?
+        };
+
+        Ok(Self {
+            device,
+            image_available_semaphore,
+            render_finished_semaphore,
+            in_flight_fence,
+        })
+    }
+}
+
+// ANCHOR: FrameSyncPrimitives Drop Implementation
+impl Drop for FrameSyncPrimitives {
+    fn drop(&mut self) {
+        unsafe {
+            self.device.destroy_semaphore(self.image_available_semaphore, None);
+            self.device.destroy_semaphore(self.render_finished_semaphore, None);
+            self.device.destroy_fence(self.in_flight_fence, None);
+        }
+        // println!("FrameSyncPrimitives dropped (IAS: {:?}, RFS: {:?}, IFF: {:?})",
+        //          self.image_available_semaphore, self.render_finished_semaphore, self.in_flight_fence);
+    }
+}


### PR DESCRIPTION
This commit introduces the foundational components for a Vulkan-based renderer for the NovaDE compositor.

Key features implemented:
- Vulkan context initialization (Instance, PhysicalDevice, LogicalDevice)
- Debug messenger setup for validation layer output
- Vulkan Memory Allocator (VMA) integration for resource management
- Swapchain management (Surface, Swapchain, ImageViews)
- Render Pass and Framebuffer creation
- Basic Graphics Pipeline for textured quads (initially using hardcoded shaders and placeholder textures)
- Command buffer recording and submission logic
- Per-frame synchronization primitives (Semaphores, Fences)
- VMA-backed VulkanBuffer and VulkanImage structs with staging buffer logic for device-local resources
- A `NovaVulkanRenderer` struct to orchestrate these components.
- A basic example (`vulkan_renderer_test`) to exercise the initialization and a mock render loop (non-visual test).

This provides a solid base for further development, including full Smithay integration for Wayland surface handling, client buffer management (SHM and DMA-BUF), and more advanced rendering features.